### PR TITLE
[2단계] 즐겨찾기 - 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ dependencies {
 	implementation 'org.jgrapht:jgrapht-core:1.0.1'
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 	implementation 'com.google.code.gson:gson:2.8.6'
+
+	compile 'io.jsonwebtoken:jjwt-api:0.11.0'
+	runtime 'io.jsonwebtoken:jjwt-impl:0.11.0',
+			'io.jsonwebtoken:jjwt-jackson:0.11.0'
+
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/src/main/java/atdd/path/application/LineService.java
+++ b/src/main/java/atdd/path/application/LineService.java
@@ -56,8 +56,6 @@ public class LineService {
                                 .findFirst().orElseThrow(RuntimeException::new);
 
         edgeRepository.deleteById(deletedEdge.getId());
-//        edgeRepository.deleteByStationId(stationId);
-//        persistLine.addEdge(newEdge);
         edgeRepository.save(newEdge);
     }
 }

--- a/src/main/java/atdd/path/application/LineService.java
+++ b/src/main/java/atdd/path/application/LineService.java
@@ -1,9 +1,6 @@
 package atdd.path.application;
 
 import atdd.path.application.exception.NoDataException;
-import atdd.path.dao.EdgeDao;
-import atdd.path.dao.LineDao;
-import atdd.path.dao.StationDao;
 import atdd.path.domain.Edge;
 import atdd.path.domain.Edges;
 import atdd.path.domain.Line;

--- a/src/main/java/atdd/path/application/dto/CreateUserRequestView.java
+++ b/src/main/java/atdd/path/application/dto/CreateUserRequestView.java
@@ -8,7 +8,7 @@ public class CreateUserRequestView {
     private String password;
 
     public User toUser() {
-       return new User(email, name);
+       return new User(email, name, password);
     }
 
     public String getName() {

--- a/src/main/java/atdd/path/application/dto/SignInUserRequestView.java
+++ b/src/main/java/atdd/path/application/dto/SignInUserRequestView.java
@@ -1,0 +1,14 @@
+package atdd.path.application.dto;
+
+public class SignInUserRequestView {
+    private String email;
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/atdd/path/auth/JwtTokenDTO.java
+++ b/src/main/java/atdd/path/auth/JwtTokenDTO.java
@@ -1,0 +1,19 @@
+package atdd.path.auth;
+
+public class JwtTokenDTO {
+    String accessToken;
+    String tokenType;
+
+    public JwtTokenDTO(String accessToken, String tokenType) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+}

--- a/src/main/java/atdd/path/auth/JwtTokenProvider.java
+++ b/src/main/java/atdd/path/auth/JwtTokenProvider.java
@@ -1,0 +1,37 @@
+package atdd.path.auth;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component()
+public class JwtTokenProvider {
+    @Autowired
+    @Value("${jwt.expireLength}")
+    String validityInMilliseconds;
+
+    private Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    public String createToken(String email) {
+
+        Claims claims = Jwts.claims().setSubject(email);
+
+        Date now = new Date();
+        Long validityInMilliseconds = Long.parseLong(this.validityInMilliseconds, 10);
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder().setClaims(claims).setIssuedAt(now).setExpiration(validity).signWith(key).compact();
+    }
+
+    public String parseToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+}

--- a/src/main/java/atdd/path/domain/User.java
+++ b/src/main/java/atdd/path/domain/User.java
@@ -40,4 +40,8 @@ public class User {
     public String getEmail() {
         return email;
     }
+
+    public String getPassword() {
+        return password;
+    }
 }

--- a/src/main/java/atdd/path/repository/UserRepository.java
+++ b/src/main/java/atdd/path/repository/UserRepository.java
@@ -3,4 +3,8 @@ package atdd.path.repository;
 import atdd.path.domain.User;
 import org.springframework.data.repository.CrudRepository;
 
-public interface UserRepository extends CrudRepository<User, Long> {}
+import java.util.Optional;
+
+public interface UserRepository extends CrudRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/atdd/path/web/UserController.java
+++ b/src/main/java/atdd/path/web/UserController.java
@@ -7,6 +7,7 @@ import atdd.path.auth.JwtTokenDTO;
 import atdd.path.auth.JwtTokenProvider;
 import atdd.path.domain.User;
 import atdd.path.repository.UserRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,32 +39,55 @@ public class UserController {
     public ResponseEntity showUsers() {
         List<User> users = new ArrayList<User>();
 
-        userRepository.findAll().forEach(users::add);
+        userRepository.findAll()
+                      .forEach(users::add);
 
-        return ResponseEntity.ok().body(UserResponseView.listOf(users));
+        return ResponseEntity.ok()
+                             .body(UserResponseView.listOf(users));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity showUser(@PathVariable Long id) {
         Optional<User> optionalUser = userRepository.findById(id);
+
         return optionalUser
-                .map(user -> ResponseEntity.ok().body(UserResponseView.of(user)))
-                .orElseGet(() -> ResponseEntity.notFound().build());
+                .map(this::getUserResponse)
+                .orElseGet(this::noContentResponse);
+    }
+
+    private ResponseEntity getUserResponse(User user) {
+        return ResponseEntity.ok().body(UserResponseView.of(user));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity deleteUser(@PathVariable Long id) {
         userRepository.deleteById(id);
-        return ResponseEntity.noContent().build();
+
+        return noContentResponse();
     }
 
     @PostMapping("/login")
     public ResponseEntity signInUser(@RequestBody SignInUserRequestView view) {
-        String accessToken = jwtTokenProvider.createToken(view.getEmail());
-        String tokenType = "Bearer";
+        Optional<User> savedUser = userRepository.findByEmail(view.getEmail());
 
-        JwtTokenDTO jwtTokenDTO = new JwtTokenDTO(accessToken, tokenType);
+        return savedUser.map(user -> getTokenOrUnAuthResponse(user, view))
+                        .orElseGet(this::noContentResponse);
+    }
 
-        return ResponseEntity.ok().body(jwtTokenDTO);
+    private ResponseEntity getTokenOrUnAuthResponse(User user, SignInUserRequestView view) {
+        boolean isValidateUser = user.getPassword().equals(view.getPassword());
+        if (isValidateUser) {
+            String accessToken = jwtTokenProvider.createToken(view.getEmail());
+            String tokenType = "Bearer";
+
+            JwtTokenDTO jwtTokenDTO = new JwtTokenDTO(accessToken, tokenType);
+
+            return ResponseEntity.ok().body(jwtTokenDTO);
+        }
+        return new ResponseEntity<String>(HttpStatus.UNAUTHORIZED);
+    }
+
+    private ResponseEntity noContentResponse() {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/atdd/path/web/UserController.java
+++ b/src/main/java/atdd/path/web/UserController.java
@@ -1,7 +1,10 @@
 package atdd.path.web;
 
 import atdd.path.application.dto.CreateUserRequestView;
+import atdd.path.application.dto.SignInUserRequestView;
 import atdd.path.application.dto.UserResponseView;
+import atdd.path.auth.JwtTokenDTO;
+import atdd.path.auth.JwtTokenProvider;
 import atdd.path.domain.User;
 import atdd.path.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +19,11 @@ import java.util.Optional;
 @RequestMapping("/users")
 public class UserController {
     private UserRepository userRepository;
+    private JwtTokenProvider jwtTokenProvider;
 
-    public UserController(UserRepository userRepository) {
+    public UserController(UserRepository userRepository, JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @PostMapping
@@ -50,5 +55,15 @@ public class UserController {
     public ResponseEntity deleteUser(@PathVariable Long id) {
         userRepository.deleteById(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity signInUser(@RequestBody SignInUserRequestView view) {
+        String accessToken = jwtTokenProvider.createToken(view.getEmail());
+        String tokenType = "Bearer";
+
+        JwtTokenDTO jwtTokenDTO = new JwtTokenDTO(accessToken, tokenType);
+
+        return ResponseEntity.ok().body(jwtTokenDTO);
     }
 }

--- a/src/main/java/atdd/path/web/UserController.java
+++ b/src/main/java/atdd/path/web/UserController.java
@@ -56,7 +56,8 @@ public class UserController {
     }
 
     private ResponseEntity getUserResponse(User user) {
-        return ResponseEntity.ok().body(UserResponseView.of(user));
+        return ResponseEntity.ok()
+                             .body(UserResponseView.of(user));
     }
 
     @DeleteMapping("/{id}")
@@ -75,19 +76,34 @@ public class UserController {
     }
 
     private ResponseEntity getTokenOrUnAuthResponse(User user, SignInUserRequestView view) {
-        boolean isValidateUser = user.getPassword().equals(view.getPassword());
+        boolean isValidateUser = user.getPassword()
+                                     .equals(view.getPassword());
         if (isValidateUser) {
             String accessToken = jwtTokenProvider.createToken(view.getEmail());
             String tokenType = "Bearer";
 
             JwtTokenDTO jwtTokenDTO = new JwtTokenDTO(accessToken, tokenType);
 
-            return ResponseEntity.ok().body(jwtTokenDTO);
+            return ResponseEntity.ok()
+                                 .body(jwtTokenDTO);
         }
         return new ResponseEntity<String>(HttpStatus.UNAUTHORIZED);
     }
 
     private ResponseEntity noContentResponse() {
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent()
+                             .build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity showSignedInUser(@RequestHeader(value = "Authorization") String authorization) {
+        String token = authorization.split(" ")[1];
+
+        String parsedEmail = jwtTokenProvider.parseToken(token);
+
+        Optional<User> optionalUser = userRepository.findByEmail(parsedEmail);
+
+        return optionalUser.map(this::getUserResponse)
+                           .orElseGet(this::noContentResponse);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+jwt.expireLength = 3600000

--- a/src/test/java/atdd/path/auth/JwtTokenProviderTest.java
+++ b/src/test/java/atdd/path/auth/JwtTokenProviderTest.java
@@ -1,0 +1,25 @@
+package atdd.path.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = JwtTokenProvider.class)
+public class JwtTokenProviderTest {
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @DisplayName("입력한 email 로 token 을 얻는다")
+    @Test
+    public void getToken() {
+        String email = "boorwonie@email.com";
+        String accessToken = jwtTokenProvider.createToken(email);
+
+        String parsedResult = jwtTokenProvider.parseToken(accessToken);
+
+        assertThat(parsedResult).isEqualTo(email);
+    }
+}

--- a/src/test/java/atdd/path/web/UserAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/UserAcceptanceTest.java
@@ -2,24 +2,25 @@ package atdd.path.web;
 
 import atdd.path.AbstractAcceptanceTest;
 import atdd.path.application.dto.UserResponseView;
-import atdd.path.auth.JwtTokenDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserAcceptanceTest extends AbstractAcceptanceTest {
-    public static final String USER_URL = "/users";
-    String firstInputJson = String.format("{\"email\": \"%s\", \"name\": \"%s\", \"password\": \"%s\"}", "boorwonie" +
-            "@email.com", "브라운", "subway");
-    String secondInputJson = String.format("{\"email\": \"%s\", \"name\": \"%s\", \"password\": \"%s\"}",
+    public static final String USER_URI = "/users";
+    public static final String SIGN_IN_URI = USER_URI + "/login";
+    public static final String FIRST_USER_INPUT_JSON = String.format("{\"email\": \"%s\", \"name\": \"%s\", \"password\": \"%s\"}",
+            "boorwonie@email.com", "브라운", "subway");
+    public static final String SECOND_USER_INPUT_JSON = String.format("{\"email\": \"%s\", \"name\": \"%s\", \"password\": \"%s\"}",
             "irrationnelle@email.com", "라세", "station");
+    public static final String SIGN_IN_JSON = String.format("{\"email\": \"%s\", \"password\" : \"%s\"}",
+            "boorwonie@email.com", "subway");
 
     private UserHttpTest userHttpTest;
 
@@ -32,106 +33,85 @@ public class UserAcceptanceTest extends AbstractAcceptanceTest {
     @Test
     public void createUser() {
         // when
-        userHttpTest.createUserSuccess(USER_URL, firstInputJson);
+        userHttpTest.createUserSuccess(USER_URI, FIRST_USER_INPUT_JSON);
 
         // then
         EntityExchangeResult<List<UserResponseView>> userResponseAfterGet = userHttpTest
-                .showUsersAndSingleUserTest(USER_URL)
+                .showUsersAndSingleUserTest(USER_URI)
                 .expectBodyList(UserResponseView.class)
                 .returnResult();
 
-        assertThat(userResponseAfterGet.getResponseBody()
-                                       .get(0)
-                                       .getName()).isEqualTo("브라운");
+        assertThat(userResponseAfterGet.getResponseBody().get(0).getName()).isEqualTo("브라운");
     }
 
     @DisplayName("회원 탈퇴")
     @Test
     public void deleteUser() {
         // given
-        Long firstUserId = userHttpTest.createUserSuccess(USER_URL, firstInputJson);
-        Long secondUserId = userHttpTest.createUserSuccess(USER_URL, secondInputJson);
+        Long firstUserId = userHttpTest.createUserSuccess(USER_URI, FIRST_USER_INPUT_JSON);
+        Long secondUserId = userHttpTest.createUserSuccess(USER_URI, SECOND_USER_INPUT_JSON);
+
+        String reqUriForFirstUser = USER_URI + "/" + firstUserId;
 
         // when
         webTestClient.delete()
-                     .uri(USER_URL + "/" + firstUserId)
+                     .uri(reqUriForFirstUser)
                      .exchange()
-                     .expectStatus()
-                     .isNoContent();
+                     .expectStatus().isNoContent();
 
         // then
         webTestClient.get()
-                     .uri(USER_URL + "/" + firstUserId)
+                     .uri(reqUriForFirstUser)
                      .exchange()
-                     .expectStatus()
-                     .isNotFound();
+                     .expectStatus().isNotFound();
 
-        String reqUriForSingleUser = USER_URL + "/" + secondUserId;
-        EntityExchangeResult<UserResponseView> userResponseAfterGet = userHttpTest
-                .showUsersAndSingleUserTest(reqUriForSingleUser)
-                .expectBody(UserResponseView.class)
-                .returnResult();
+        String reqUriForSecondUser = USER_URI + "/" + secondUserId;
+        EntityExchangeResult<UserResponseView> userResponseAfterGet =
+                userHttpTest.showUsersAndSingleUserTest(reqUriForSecondUser)
+                            .expectBody(UserResponseView.class)
+                            .returnResult();
 
-        assertThat(userResponseAfterGet.getResponseBody()
-                                       .getName()).isEqualTo("라세");
+        assertThat(userResponseAfterGet.getResponseBody().getName()).isEqualTo("라세");
     }
 
     @DisplayName("로그인 요청 후 토큰 발급")
     @Test
     public void signInUser() {
         // given
-        userHttpTest.createUserSuccess(USER_URL, firstInputJson);
+        userHttpTest.createUserSuccess(USER_URI, FIRST_USER_INPUT_JSON);
 
-        String signInUri = USER_URL + "/login";
-        String inputJson = String.format("{\"email\": \"%s\", \"password\" : \"%s\"}", "boorwonie@email.com", "subway");
+        // when
+        String tokenInfo = userHttpTest.createAuthorizationTokenSuccess(SIGN_IN_URI, SIGN_IN_JSON);
 
-        EntityExchangeResult<JwtTokenDTO> getTokenResponse = webTestClient
-                .post()
-                .uri(signInUri)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(inputJson), String.class)
-                .exchange()
-                .expectStatus()
-                .isOk()
-                .expectHeader()
-                .contentType(MediaType.APPLICATION_JSON)
-                .expectBody(JwtTokenDTO.class)
-                .consumeWith(result -> {
-                    assertThat(result.getResponseBody()
-                                     .getAccessToken()).isNotEmpty();
-                    assertThat(result.getResponseBody()
-                                     .getTokenType()).isNotEmpty();
-                })
-                .returnResult();
+        // then
+        assertThat(tokenInfo).isNotEmpty();
 
+        // when
         String improperJson = String.format("{\"email\": \"%s\", \"password\" : \"%s\"}", "boorwonie@email.com", "station");
 
-        webTestClient
-                .post()
-                .uri(signInUri)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(improperJson), String.class)
-                .exchange()
-                .expectStatus()
-                .isUnauthorized();
+        // then
+        userHttpTest.createAuthorizationTokenTest(SIGN_IN_URI, improperJson).isUnauthorized();
+    }
 
-        String accessToken = getTokenResponse.getResponseBody()
-                                             .getAccessToken();
-        String tokenType = getTokenResponse.getResponseBody()
-                                           .getTokenType();
+    @DisplayName("발급받은 토큰으로 유저 정보 받아오기")
+    @Test
+    public void getUserInfoWithToken() {
+        // given
+        userHttpTest.createUserSuccess(USER_URI, FIRST_USER_INPUT_JSON);
+        String tokenInfo = userHttpTest.createAuthorizationTokenSuccess(SIGN_IN_URI, SIGN_IN_JSON);
 
+        // when and then
         webTestClient.get()
-                     .uri(USER_URL + "/me")
-                     .header("Authorization", tokenType + " " + accessToken)
+                     .uri(USER_URI + "/me")
+                     .header("Authorization", tokenInfo)
                      .exchange()
-                     .expectStatus()
-                     .isOk()
-                     .expectHeader()
-                     .contentType(MediaType.APPLICATION_JSON)
-                     .expectBody(UserResponseView.class)
-                     .consumeWith(result -> {
-                         assertThat(result.getResponseBody().getName()).isEqualTo("브라운");
-                         assertThat(result.getResponseBody().getEmail()).isEqualTo("boorwonie@email.com");
-                     });
+                     .expectStatus().isOk()
+                     .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                     .expectBody(UserResponseView.class).consumeWith(this::getUserInfoAssert);
+    }
+
+    private void getUserInfoAssert(EntityExchangeResult<UserResponseView> result) {
+        assertThat(result.getResponseBody().getName()).isEqualTo("브라운");
+        assertThat(result.getResponseBody().getEmail()).isEqualTo("boorwonie@email.com");
     }
 }

--- a/src/test/java/atdd/path/web/UserAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/UserAcceptanceTest.java
@@ -39,7 +39,9 @@ public class UserAcceptanceTest extends AbstractAcceptanceTest {
                 .expectBodyList(UserResponseView.class)
                 .returnResult();
 
-        assertThat(userResponseAfterGet.getResponseBody().get(0).getName()).isEqualTo("브라운");
+        assertThat(userResponseAfterGet.getResponseBody()
+                                       .get(0)
+                                       .getName()).isEqualTo("브라운");
     }
 
     @DisplayName("회원 탈퇴")
@@ -50,10 +52,18 @@ public class UserAcceptanceTest extends AbstractAcceptanceTest {
         Long secondUserId = userHttpTest.createUserSuccess(USER_URL, secondInputJson);
 
         // when
-        webTestClient.delete().uri(USER_URL + "/" + firstUserId).exchange().expectStatus().isNoContent();
+        webTestClient.delete()
+                     .uri(USER_URL + "/" + firstUserId)
+                     .exchange()
+                     .expectStatus()
+                     .isNoContent();
 
         // then
-        webTestClient.get().uri(USER_URL + "/" + firstUserId).exchange().expectStatus().isNotFound();
+        webTestClient.get()
+                     .uri(USER_URL + "/" + firstUserId)
+                     .exchange()
+                     .expectStatus()
+                     .isNotFound();
 
         String reqUriForSingleUser = USER_URL + "/" + secondUserId;
         EntityExchangeResult<UserResponseView> userResponseAfterGet = userHttpTest
@@ -61,17 +71,18 @@ public class UserAcceptanceTest extends AbstractAcceptanceTest {
                 .expectBody(UserResponseView.class)
                 .returnResult();
 
-        assertThat(userResponseAfterGet.getResponseBody().getName()).isEqualTo("라세");
+        assertThat(userResponseAfterGet.getResponseBody()
+                                       .getName()).isEqualTo("라세");
     }
 
     @DisplayName("로그인 요청 후 토큰 발급")
     @Test
     public void signInUser() {
         // given
-        Long firstUserId = userHttpTest.createUserSuccess(USER_URL, firstInputJson);
+        userHttpTest.createUserSuccess(USER_URL, firstInputJson);
 
-        String signInUri = "/login";
-        String inputJson = String.format("{\"email\": %s, \"password\" : %s", "boorwonie@email.com", "subway");
+        String signInUri = USER_URL + "/login";
+        String inputJson = String.format("{\"email\": \"%s\", \"password\" : \"%s\"}", "boorwonie@email.com", "subway");
 
         EntityExchangeResult<?> response = webTestClient
                 .post()
@@ -84,8 +95,21 @@ public class UserAcceptanceTest extends AbstractAcceptanceTest {
                 .expectHeader()
                 .contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$.accessToken").isNotEmpty()
-                .jsonPath("$.tokenType").isNotEmpty()
+                .jsonPath("$.accessToken")
+                .isNotEmpty()
+                .jsonPath("$.tokenType")
+                .isNotEmpty()
                 .returnResult();
+
+        String improperJson = String.format("{\"email\": \"%s\", \"password\" : \"%s\"}", "boorwonie@email.com", "station");
+
+        webTestClient
+                .post()
+                .uri(signInUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(improperJson), String.class)
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
     }
 }

--- a/src/test/java/atdd/path/web/UserHttpTest.java
+++ b/src/test/java/atdd/path/web/UserHttpTest.java
@@ -1,9 +1,11 @@
 package atdd.path.web;
 
 import atdd.path.application.dto.UserResponseView;
+import atdd.path.auth.JwtTokenDTO;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.StatusAssertions;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
@@ -25,19 +27,10 @@ public class UserHttpTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(Mono.just(inputJson), String.class)
                 .exchange()
-                .expectStatus()
-                .isCreated()
-                .expectHeader()
-                .contentType(MediaType.APPLICATION_JSON)
-                .expectHeader()
-                .exists("Location")
-                .expectBody(UserResponseView.class)
-                .consumeWith(result -> {
-                    HttpHeaders responseHeaders = result.getResponseHeaders();
-                    URI location = responseHeaders.getLocation();
-                    String stringifyLocation = location.toString();
-                    assertThat(stringifyLocation).isEqualTo(reqUri + "/" + result.getResponseBody().getId());
-                })
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectHeader().exists("Location")
+                .expectBody(UserResponseView.class).consumeWith(result -> createUserAssert(result, reqUri))
                 .returnResult();
     }
 
@@ -51,9 +44,43 @@ public class UserHttpTest {
                 .get()
                 .uri(reqUri)
                 .exchange()
-                .expectStatus()
-                .isOk()
-                .expectHeader()
-                .contentType(MediaType.APPLICATION_JSON);
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON);
+    }
+
+    public StatusAssertions createAuthorizationTokenTest(String reqUri, String inputJson) {
+        return webTestClient
+                .post()
+                .uri(reqUri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(inputJson), String.class)
+                .exchange()
+                .expectStatus();
+    }
+
+    public String createAuthorizationTokenSuccess(String reqUri, String inputJson) {
+        EntityExchangeResult<JwtTokenDTO> getTokenResponse = createAuthorizationTokenTest(reqUri, inputJson).isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(JwtTokenDTO.class).consumeWith(this::createTokenResultAssert)
+                .returnResult();
+
+        String accessToken = getTokenResponse.getResponseBody().getAccessToken();
+        String tokenType = getTokenResponse.getResponseBody().getTokenType();
+
+        String tokenInfo = tokenType + " " + accessToken;
+
+        return tokenInfo;
+    }
+
+    private void createTokenResultAssert(EntityExchangeResult<JwtTokenDTO> result) {
+        assertThat(result.getResponseBody().getAccessToken()).isNotEmpty();
+        assertThat(result.getResponseBody().getTokenType()).isNotEmpty();
+    }
+
+    private void createUserAssert(EntityExchangeResult<UserResponseView> result, String reqUri) {
+        HttpHeaders responseHeaders = result.getResponseHeaders();
+        URI location = responseHeaders.getLocation();
+        String stringifyLocation = location.toString();
+        assertThat(stringifyLocation).isEqualTo(reqUri + "/" + result.getResponseBody().getId());
     }
 }


### PR DESCRIPTION
```java
return optionalUser
                .map(user -> ResponseEntity.ok().body(UserResponseView.of(user)))
                .orElseGet(() -> ResponseEntity.notFound().build());
```
위 코드에 대해 아래와 같이 리뷰를 주셨는데, 리뷰 주신 것처럼 변경할 경우 `orElseGet`는 어떻게 변환해야 하나요? `isPresent()`를 이용해서 따로 관리해 주어야 할까요? ㅠㅠ

```java
return ResponseEntity.of(
        optionalUser.map(UserResponseView::of)
);
```

---

`isPresent()`와 if 문을 이용해서 외부에서 따로 not found 를 구현하는 방법이 마음에 들지 않아서 저는 다음과 같은 접근으로 수정을 했습니다

```java
return optionalUser.map(this::getUserResponse)
                           .orElseGet(this::notFoundResponse);

...

private ResponseEntity getUserResponse(User user) {
        return ResponseEntity.ok().body(UserResponseView.of(user));
    }

private ResponseEntity notFoundResponse() {
        return ResponseEntity.notFound().build();
    }
```
