### PR TITLE
[2주차/3단계] 즐겨찾기 - 즐겨찾기

### DIFF
--- a/src/main/java/atdd/path/application/FavoriteService.java
+++ b/src/main/java/atdd/path/application/FavoriteService.java
@@ -24,8 +24,10 @@ public class FavoriteService {
         return favoriteDao.saveForStation(new FavoriteStation(member, findStation));
     }
 
-    public FavoritePath saveFavoritePath(Long startId, Long endId, Member member) {
-        return null;
+    public FavoritePath saveForPath(Member member, Long startId, Long endId) {
+        final Station sourceStation = stationDao.findById(startId);
+        final Station targetStation = stationDao.findById(endId);
+        return favoriteDao.saveForPath(new FavoritePath(member, sourceStation, targetStation));
     }
 
 }

--- a/src/main/java/atdd/path/application/FavoriteService.java
+++ b/src/main/java/atdd/path/application/FavoriteService.java
@@ -1,0 +1,26 @@
+package atdd.path.application;
+
+import atdd.path.dao.FavoriteDao;
+import atdd.path.dao.StationDao;
+import atdd.path.domain.FavoriteStation;
+import atdd.path.domain.Member;
+import atdd.path.domain.Station;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FavoriteService {
+
+    private final FavoriteDao favoriteDao;
+    private final StationDao stationDao;
+
+    public FavoriteService(FavoriteDao favoriteDao, StationDao stationDao) {
+        this.favoriteDao = favoriteDao;
+        this.stationDao = stationDao;
+    }
+
+    public FavoriteStation saveForStation(Member member, Long stationId) {
+        final Station findStation = stationDao.findById(stationId);
+        return favoriteDao.saveForStation(member, findStation);
+    }
+
+}

--- a/src/main/java/atdd/path/application/FavoriteService.java
+++ b/src/main/java/atdd/path/application/FavoriteService.java
@@ -2,6 +2,7 @@ package atdd.path.application;
 
 import atdd.path.dao.FavoriteDao;
 import atdd.path.dao.StationDao;
+import atdd.path.domain.FavoritePath;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
 import atdd.path.domain.Station;
@@ -21,6 +22,10 @@ public class FavoriteService {
     public FavoriteStation saveForStation(Member member, Long stationId) {
         final Station findStation = stationDao.findById(stationId);
         return favoriteDao.saveForStation(new FavoriteStation(member, findStation));
+    }
+
+    public FavoritePath saveFavoritePath(Long startId, Long endId, Member member) {
+        return null;
     }
 
 }

--- a/src/main/java/atdd/path/application/FavoriteService.java
+++ b/src/main/java/atdd/path/application/FavoriteService.java
@@ -8,6 +8,8 @@ import atdd.path.domain.Member;
 import atdd.path.domain.Station;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class FavoriteService {
 
@@ -28,6 +30,22 @@ public class FavoriteService {
         final Station sourceStation = stationDao.findById(startId);
         final Station targetStation = stationDao.findById(endId);
         return favoriteDao.saveForPath(new FavoritePath(member, sourceStation, targetStation));
+    }
+
+    public List<FavoriteStation> findForStations(Member member) {
+        return favoriteDao.findForStations(member);
+    }
+
+    public void deleteForStationById(Long favoriteId) {
+        favoriteDao.deleteForStationById(favoriteId);
+    }
+
+    public List<FavoritePath> findForPaths(Member member) {
+        return favoriteDao.findForPaths(member);
+    }
+
+    public void deleteForPathById(Long favoriteId) {
+        favoriteDao.deleteForPathById(favoriteId);
     }
 
 }

--- a/src/main/java/atdd/path/application/FavoriteService.java
+++ b/src/main/java/atdd/path/application/FavoriteService.java
@@ -20,7 +20,7 @@ public class FavoriteService {
 
     public FavoriteStation saveForStation(Member member, Long stationId) {
         final Station findStation = stationDao.findById(stationId);
-        return favoriteDao.saveForStation(member, findStation);
+        return favoriteDao.saveForStation(new FavoriteStation(member, findStation));
     }
 
 }

--- a/src/main/java/atdd/path/application/FavoriteService.java
+++ b/src/main/java/atdd/path/application/FavoriteService.java
@@ -1,5 +1,6 @@
 package atdd.path.application;
 
+import atdd.path.application.exception.ConflictException;
 import atdd.path.dao.FavoriteDao;
 import atdd.path.dao.StationDao;
 import atdd.path.domain.FavoritePath;
@@ -29,6 +30,11 @@ public class FavoriteService {
     public FavoritePath saveForPath(Member member, Long startId, Long endId) {
         final Station sourceStation = stationDao.findById(startId);
         final Station targetStation = stationDao.findById(endId);
+
+        if (sourceStation.isSameStation(targetStation)) {
+            throw new ConflictException("same station conflict");
+        }
+
         return favoriteDao.saveForPath(new FavoritePath(member, sourceStation, targetStation));
     }
 

--- a/src/main/java/atdd/path/application/GraphService.java
+++ b/src/main/java/atdd/path/application/GraphService.java
@@ -1,6 +1,7 @@
 package atdd.path.application;
 
 import atdd.path.dao.LineDao;
+import atdd.path.domain.FavoritePath;
 import atdd.path.domain.Graph;
 import atdd.path.domain.Line;
 import atdd.path.domain.Station;
@@ -21,4 +22,9 @@ public class GraphService {
         Graph graph = new Graph(lines);
         return graph.getShortestDistancePath(startId, endId);
     }
+
+    public List<Station> findPath(FavoritePath favoritePath) {
+        return findPath(favoritePath.getSourceStation().getId(), favoritePath.getTargetStation().getId());
+    }
+
 }

--- a/src/main/java/atdd/path/application/GraphService.java
+++ b/src/main/java/atdd/path/application/GraphService.java
@@ -24,7 +24,7 @@ public class GraphService {
     }
 
     public List<Station> findPath(FavoritePath favoritePath) {
-        return findPath(favoritePath.getSourceStation().getId(), favoritePath.getTargetStation().getId());
+        return findPath(favoritePath.getSourceStationId(), favoritePath.getTargetStationId());
     }
 
 }

--- a/src/main/java/atdd/path/application/config/WebMvcConfig.java
+++ b/src/main/java/atdd/path/application/config/WebMvcConfig.java
@@ -22,7 +22,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(loginInterceptor).addPathPatterns("/members/me");
+        registry.addInterceptor(loginInterceptor).addPathPatterns("/members/me", "/favorites/**");
     }
 
     @Override

--- a/src/main/java/atdd/path/application/dto/FavoritePathResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoritePathResponseView.java
@@ -15,8 +15,8 @@ public class FavoritePathResponseView {
     public FavoritePathResponseView(FavoritePath favoritePath, List<Station> stations) {
         this.id = favoritePath.getId();
         this.path = new PathResponseView(
-                favoritePath.getSourceStation().getId(),
-                favoritePath.getTargetStation().getId(),
+                favoritePath.getSourceStationId(),
+                favoritePath.getTargetStationId(),
                 stations);
     }
 

--- a/src/main/java/atdd/path/application/dto/FavoritePathResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoritePathResponseView.java
@@ -1,0 +1,29 @@
+package atdd.path.application.dto;
+
+import atdd.path.domain.FavoritePath;
+import atdd.path.domain.Station;
+
+import java.util.List;
+
+public class FavoritePathResponseView {
+
+    private Long id;
+    private PathResponseView path;
+
+    private FavoritePathResponseView() { }
+
+    public FavoritePathResponseView(FavoritePath favoritePath, List<Station> stations) {
+        this.id = favoritePath.getId();
+        this.path = new PathResponseView(favoritePath.getSourceStation().getId(),
+                favoritePath.getTargetStation().getId(), stations);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public PathResponseView getPath() {
+        return path;
+    }
+
+}

--- a/src/main/java/atdd/path/application/dto/FavoritePathResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoritePathResponseView.java
@@ -14,8 +14,10 @@ public class FavoritePathResponseView {
 
     public FavoritePathResponseView(FavoritePath favoritePath, List<Station> stations) {
         this.id = favoritePath.getId();
-        this.path = new PathResponseView(favoritePath.getSourceStation().getId(),
-                favoritePath.getTargetStation().getId(), stations);
+        this.path = new PathResponseView(
+                favoritePath.getSourceStation().getId(),
+                favoritePath.getTargetStation().getId(),
+                stations);
     }
 
     public Long getId() {

--- a/src/main/java/atdd/path/application/dto/FavoritePathsResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoritePathsResponseView.java
@@ -1,0 +1,25 @@
+package atdd.path.application.dto;
+
+import java.util.List;
+
+public class FavoritePathsResponseView {
+
+    private int count;
+    private List<FavoritePathResponseView> favorites;
+
+    private FavoritePathsResponseView() {}
+
+    public FavoritePathsResponseView(List<FavoritePathResponseView> favorites) {
+        this.count = favorites.size();
+        this.favorites = favorites;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<FavoritePathResponseView> getFavorites() {
+        return favorites;
+    }
+
+}

--- a/src/main/java/atdd/path/application/dto/FavoritePathsResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoritePathsResponseView.java
@@ -4,18 +4,16 @@ import java.util.List;
 
 public class FavoritePathsResponseView {
 
-    private int count;
     private List<FavoritePathResponseView> favorites;
 
     private FavoritePathsResponseView() {}
 
     public FavoritePathsResponseView(List<FavoritePathResponseView> favorites) {
-        this.count = favorites.size();
         this.favorites = favorites;
     }
 
     public int getCount() {
-        return count;
+        return favorites.size();
     }
 
     public List<FavoritePathResponseView> getFavorites() {

--- a/src/main/java/atdd/path/application/dto/FavoriteStationResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoriteStationResponseView.java
@@ -1,0 +1,25 @@
+package atdd.path.application.dto;
+
+import atdd.path.domain.FavoriteStation;
+
+public class FavoriteStationResponseView {
+
+    private Long id;
+    private StationResponseView station;
+
+    private FavoriteStationResponseView() {}
+
+    public FavoriteStationResponseView(FavoriteStation favoriteStation) {
+        this.id = favoriteStation.getId();
+        this.station = StationResponseView.of(favoriteStation.getStation());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StationResponseView getStation() {
+        return station;
+    }
+
+}

--- a/src/main/java/atdd/path/application/dto/FavoriteStationResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoriteStationResponseView.java
@@ -4,20 +4,22 @@ import atdd.path.domain.FavoriteStation;
 
 public class FavoriteStationResponseView {
 
-    private FavoriteStation favoriteStation;
+    private Long id;
+    private StationResponseView station;
 
     private FavoriteStationResponseView() {}
 
     public FavoriteStationResponseView(FavoriteStation favoriteStation) {
-        this.favoriteStation = favoriteStation;
+        this.id = favoriteStation.getId();
+        this.station = StationResponseView.of(favoriteStation.getStation());
     }
 
     public Long getId() {
-        return favoriteStation.getId();
+        return id;
     }
 
     public StationResponseView getStation() {
-        return StationResponseView.of(favoriteStation.getStation());
+        return station;
     }
 
 }

--- a/src/main/java/atdd/path/application/dto/FavoriteStationResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoriteStationResponseView.java
@@ -4,22 +4,20 @@ import atdd.path.domain.FavoriteStation;
 
 public class FavoriteStationResponseView {
 
-    private Long id;
-    private StationResponseView station;
+    private FavoriteStation favoriteStation;
 
     private FavoriteStationResponseView() {}
 
     public FavoriteStationResponseView(FavoriteStation favoriteStation) {
-        this.id = favoriteStation.getId();
-        this.station = StationResponseView.of(favoriteStation.getStation());
+        this.favoriteStation = favoriteStation;
     }
 
     public Long getId() {
-        return id;
+        return favoriteStation.getId();
     }
 
     public StationResponseView getStation() {
-        return station;
+        return StationResponseView.of(favoriteStation.getStation());
     }
 
 }

--- a/src/main/java/atdd/path/application/dto/FavoriteStationsResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoriteStationsResponseView.java
@@ -1,0 +1,31 @@
+package atdd.path.application.dto;
+
+import atdd.path.domain.FavoriteStation;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class FavoriteStationsResponseView {
+
+    private int count;
+    private List<FavoriteStationResponseView> favorites;
+
+    private FavoriteStationsResponseView() {}
+
+    public FavoriteStationsResponseView(List<FavoriteStation> favorites) {
+        this.count = favorites.size();
+        this.favorites = favorites.stream()
+                .map(FavoriteStationResponseView::new)
+                .collect(toList());
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<FavoriteStationResponseView> getFavorites() {
+        return favorites;
+    }
+
+}

--- a/src/main/java/atdd/path/application/dto/FavoriteStationsResponseView.java
+++ b/src/main/java/atdd/path/application/dto/FavoriteStationsResponseView.java
@@ -8,20 +8,18 @@ import static java.util.stream.Collectors.toList;
 
 public class FavoriteStationsResponseView {
 
-    private int count;
     private List<FavoriteStationResponseView> favorites;
 
     private FavoriteStationsResponseView() {}
 
     public FavoriteStationsResponseView(List<FavoriteStation> favorites) {
-        this.count = favorites.size();
         this.favorites = favorites.stream()
                 .map(FavoriteStationResponseView::new)
                 .collect(toList());
     }
 
     public int getCount() {
-        return count;
+        return favorites.size();
     }
 
     public List<FavoriteStationResponseView> getFavorites() {

--- a/src/main/java/atdd/path/application/dto/MemberResponseView.java
+++ b/src/main/java/atdd/path/application/dto/MemberResponseView.java
@@ -2,8 +2,6 @@ package atdd.path.application.dto;
 
 import atdd.path.domain.Member;
 
-import java.util.StringJoiner;
-
 public class MemberResponseView {
 
     private Long id;
@@ -11,7 +9,7 @@ public class MemberResponseView {
     private String name;
     private String password;
 
-    protected MemberResponseView() {}
+    private MemberResponseView() {}
 
     public MemberResponseView(Member member) {
         this.id = member.getId();
@@ -34,15 +32,6 @@ public class MemberResponseView {
 
     public String getPassword() {
         return password;
-    }
-
-    @Override
-    public String toString() {
-        return new StringJoiner(", ", MemberResponseView.class.getSimpleName() + "[", "]")
-                .add("id=" + id)
-                .add("email='" + email + "'")
-                .add("name='" + name + "'")
-                .toString();
     }
 
 }

--- a/src/main/java/atdd/path/application/exception/BadRequestException.java
+++ b/src/main/java/atdd/path/application/exception/BadRequestException.java
@@ -1,0 +1,16 @@
+package atdd.path.application.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException() {
+    }
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/atdd/path/application/exception/ConflictException.java
+++ b/src/main/java/atdd/path/application/exception/ConflictException.java
@@ -1,0 +1,15 @@
+package atdd.path.application.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+
+    public ConflictException() { }
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/atdd/path/application/interceptor/LoginInterceptor.java
+++ b/src/main/java/atdd/path/application/interceptor/LoginInterceptor.java
@@ -2,6 +2,7 @@ package atdd.path.application.interceptor;
 
 import atdd.path.application.exception.InvalidJwtAuthenticationException;
 import atdd.path.application.provider.JwtTokenProvider;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -9,7 +10,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static atdd.path.application.provider.JwtTokenProvider.AUTHORIZATION;
 import static atdd.path.application.provider.JwtTokenProvider.TOKEN_TYPE;
 
 @Component
@@ -35,7 +35,7 @@ public class LoginInterceptor implements HandlerInterceptor {
     }
 
     private String extractToken(HttpServletRequest request) {
-        final String header = request.getHeader(AUTHORIZATION);
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (StringUtils.isEmpty(header)) {
             return "";

--- a/src/main/java/atdd/path/application/provider/JwtTokenProvider.java
+++ b/src/main/java/atdd/path/application/provider/JwtTokenProvider.java
@@ -11,7 +11,6 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     public static final String TOKEN_TYPE = "bearer";
-    public static final String AUTHORIZATION = "authorization";
 
     @Value("${spring.security.jwt.token.secret-key}")
     private String secretKey;

--- a/src/main/java/atdd/path/application/resolver/LoginUserHandlerMethodArgumentResolver.java
+++ b/src/main/java/atdd/path/application/resolver/LoginUserHandlerMethodArgumentResolver.java
@@ -2,7 +2,6 @@ package atdd.path.application.resolver;
 
 import atdd.path.application.exception.InvalidJwtAuthenticationException;
 import atdd.path.dao.MemberDao;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -31,11 +30,6 @@ public class LoginUserHandlerMethodArgumentResolver implements HandlerMethodArgu
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
         String email = (String) webRequest.getAttribute("loginUserEmail", SCOPE_REQUEST);
-
-        if (Strings.isBlank(email)) {
-            return null;
-        }
-
         return memberDao.findByEmail(email).orElseThrow(InvalidJwtAuthenticationException::new);
     }
 

--- a/src/main/java/atdd/path/application/resolver/LoginUserHandlerMethodArgumentResolver.java
+++ b/src/main/java/atdd/path/application/resolver/LoginUserHandlerMethodArgumentResolver.java
@@ -2,6 +2,7 @@ package atdd.path.application.resolver;
 
 import atdd.path.application.exception.InvalidJwtAuthenticationException;
 import atdd.path.dao.MemberDao;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -9,6 +10,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import static atdd.path.domain.Guest.GUEST_MEMBER;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
 @Component
@@ -30,6 +32,11 @@ public class LoginUserHandlerMethodArgumentResolver implements HandlerMethodArgu
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
         String email = (String) webRequest.getAttribute("loginUserEmail", SCOPE_REQUEST);
+
+        if (Strings.isBlank(email)) {
+            return GUEST_MEMBER;
+        }
+
         return memberDao.findByEmail(email).orElseThrow(InvalidJwtAuthenticationException::new);
     }
 

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -139,10 +139,31 @@ public class FavoriteDao {
                     stationOf(rs, "SOURCE"),
                     stationOf(rs, "TARGET"));
 
+    public List<FavoritePath> findForPaths(Member member) {
+        final String sql = "select fp.id, " +
+                "m.id as member_id, " +
+                "m.email, " +
+                "m.name, " +
+                "s1.id as source_station_id,   " +
+                "s1.name as source_station_name,  " +
+                "s2.id as target_station_id,   " +
+                "s2.name as target_station_name  " +
+                "from favorite_path fp " +
+                "inner join member m on fp.member_id = m.id " +
+                "inner join station s1 on fp.source_station_id = s1.id " +
+                "inner join station s2 on fp.target_station_id = s2.id " +
+                "where fp.member_id = ?";
+
+        return jdbcTemplate.query(
+                sql,
+                new Object[]{member.getId()},
+                pathRowMapper);
+    }
+
     private static Station stationOf(ResultSet rs, String prefix) throws SQLException {
         final String newPrefix = StringUtils.isEmpty(prefix) ? "" : prefix + "_";
         return new Station(rs.getLong(newPrefix + "STATION_ID"),
-                rs.getString(newPrefix +"STATION_NAME"));
+                rs.getString(newPrefix + "STATION_NAME"));
     }
 
     private static Member memberOf(ResultSet rs) throws SQLException {
@@ -151,8 +172,5 @@ public class FavoriteDao {
                 rs.getString("NAME"),
                 "");
     }
-
-    public List<FavoritePath> findFavoritePath(Member member) {
-        return null;
-    }
+    
 }

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -46,8 +46,8 @@ public class FavoriteDao {
 
     public FavoriteStation saveForStation(FavoriteStation favoriteStation) {
         final Map<String, Long> params = Map.ofEntries(
-                Map.entry("member_id", favoriteStation.getMember().getId()),
-                Map.entry("station_id", favoriteStation.getStation().getId())
+                Map.entry("member_id", favoriteStation.getMemberId()),
+                Map.entry("station_id", favoriteStation.getStationId())
         );
 
         final Long favoriteId = stationSimpleJdbcInsert.executeAndReturnKey(params).longValue();
@@ -103,8 +103,8 @@ public class FavoriteDao {
     public FavoritePath saveForPath(FavoritePath favoritePath) {
         final Map<String, Long> params = Map.ofEntries(
                 Map.entry("member_id", favoritePath.getMember().getId()),
-                Map.entry("source_station_id", favoritePath.getSourceStation().getId()),
-                Map.entry("target_station_id", favoritePath.getTargetStation().getId())
+                Map.entry("source_station_id", favoritePath.getSourceStationId()),
+                Map.entry("target_station_id", favoritePath.getTargetStationId())
         );
 
         final Long favoriteId = pathSimpleJdbcInsert.executeAndReturnKey(params).longValue();

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -1,0 +1,69 @@
+package atdd.path.dao;
+
+import atdd.path.application.exception.NoDataException;
+import atdd.path.domain.FavoriteStation;
+import atdd.path.domain.Member;
+import atdd.path.domain.Station;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+
+@Repository
+public class FavoriteDao {
+
+    private final JdbcTemplate jdbcTemplate;
+    private SimpleJdbcInsert simpleJdbcInsert;
+
+    public FavoriteDao(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Autowired
+    public void setDataSource(final DataSource dataSource) {
+        this.simpleJdbcInsert = new SimpleJdbcInsert(dataSource)
+                .withTableName("FAVORITE_STATION")
+                .usingGeneratedKeyColumns("ID");
+    }
+
+    public FavoriteStation saveForStation(Member member, Station station) {
+        final Map<String, Long> params = Map.ofEntries(
+                Map.entry("member_id", member.getId()),
+                Map.entry("station_id", station.getId())
+        );
+
+        final Long favoriteId = simpleJdbcInsert.executeAndReturnKey(params).longValue();
+        return findFavoriteStationById(favoriteId).orElseThrow(NoDataException::new);
+    }
+
+    private Optional<FavoriteStation> findFavoriteStationById(Long favoriteId) {
+        final String sql = "select fs.id, s.id as station_id, s.name as station_name " +
+                "from favorite_station fs " +
+                "inner join station s on fs.station_id = s.id " +
+                "where fs.id = ?";
+
+        final List<FavoriteStation> results = jdbcTemplate.query(
+                sql,
+                new Object[]{favoriteId},
+                mapper);
+
+        return ofNullable(CollectionUtils.isEmpty(results) ? null : results.get(0));
+    }
+
+    private static RowMapper<FavoriteStation> mapper = (rs, rowNum) -> {
+        Station findStation = new Station(
+                rs.getLong("STATION_ID"), rs.getString("STATION_NAME"));
+
+        return new FavoriteStation(rs.getLong("ID"), findStation);
+    };
+
+}

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -152,4 +152,7 @@ public class FavoriteDao {
                 "");
     }
 
+    public List<FavoritePath> findFavoritePath(Member member) {
+        return null;
+    }
 }

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -133,12 +133,6 @@ public class FavoriteDao {
         return ofNullable(CollectionUtils.isEmpty(results) ? null : results.get(0));
     }
 
-    private static RowMapper<FavoritePath> pathRowMapper = (rs, rowNum) ->
-            new FavoritePath(rs.getLong("ID"),
-                    memberOf(rs),
-                    stationOf(rs, "SOURCE"),
-                    stationOf(rs, "TARGET"));
-
     public List<FavoritePath> findForPaths(Member member) {
         final String sql = "select fp.id, " +
                 "m.id as member_id, " +
@@ -160,6 +154,17 @@ public class FavoriteDao {
                 pathRowMapper);
     }
 
+    private static RowMapper<FavoritePath> pathRowMapper = (rs, rowNum) ->
+            new FavoritePath(rs.getLong("ID"),
+                    memberOf(rs),
+                    stationOf(rs, "SOURCE"),
+                    stationOf(rs, "TARGET"));
+
+    public void deleteForPathById(Long favoriteId) {
+        final FavoritePath findFavorite = findFavoritePathById(favoriteId).orElseThrow(NoDataException::new);
+        jdbcTemplate.update("delete from favorite_path where id = ?", findFavorite.getId());
+    }
+
     private static Station stationOf(ResultSet rs, String prefix) throws SQLException {
         final String newPrefix = StringUtils.isEmpty(prefix) ? "" : prefix + "_";
         return new Station(rs.getLong(newPrefix + "STATION_ID"),
@@ -172,5 +177,5 @@ public class FavoriteDao {
                 rs.getString("NAME"),
                 "");
     }
-    
+
 }

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -60,7 +60,15 @@ public class FavoriteDao {
     }
 
     public List<FavoriteStation> findForStations(Long memberId) {
-        return null;
+        final String sql = "select fs.id, s.id as station_id, s.name as station_name " +
+                "from favorite_station fs " +
+                "inner join station s on fs.station_id = s.id " +
+                "where fs.member_id = ?";
+
+        return jdbcTemplate.query(
+                sql,
+                new Object[]{memberId},
+                mapper);
     }
 
     private static RowMapper<FavoriteStation> mapper = (rs, rowNum) -> {

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -1,6 +1,7 @@
 package atdd.path.dao;
 
 import atdd.path.application.exception.NoDataException;
+import atdd.path.domain.FavoritePath;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
 import atdd.path.domain.Station;
@@ -43,6 +44,10 @@ public class FavoriteDao {
 
         final Long favoriteId = simpleJdbcInsert.executeAndReturnKey(params).longValue();
         return findFavoriteStationById(favoriteId).orElseThrow(NoDataException::new);
+    }
+
+    public FavoritePath saveForPath(FavoritePath favoritePath) {
+        return null;
     }
 
     private Optional<FavoriteStation> findFavoriteStationById(Long favoriteId) {

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -78,4 +78,9 @@ public class FavoriteDao {
         return new FavoriteStation(rs.getLong("ID"), findStation);
     };
 
+    public void deleteForStationById(Long favoriteId) {
+        final FavoriteStation findFavorite = findFavoriteStationById(favoriteId).orElseThrow(NoDataException::new);
+        jdbcTemplate.update("delete from favorite_station where id = ?", findFavorite.getId());
+    }
+
 }

--- a/src/main/java/atdd/path/dao/FavoriteDao.java
+++ b/src/main/java/atdd/path/dao/FavoriteDao.java
@@ -59,6 +59,10 @@ public class FavoriteDao {
         return ofNullable(CollectionUtils.isEmpty(results) ? null : results.get(0));
     }
 
+    public List<FavoriteStation> findForStations(Long memberId) {
+        return null;
+    }
+
     private static RowMapper<FavoriteStation> mapper = (rs, rowNum) -> {
         Station findStation = new Station(
                 rs.getLong("STATION_ID"), rs.getString("STATION_NAME"));

--- a/src/main/java/atdd/path/dao/StationDao.java
+++ b/src/main/java/atdd/path/dao/StationDao.java
@@ -13,7 +13,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 @Repository
 public class StationDao {
@@ -84,13 +85,12 @@ public class StationDao {
             return Collections.EMPTY_LIST;
         }
 
-        return result.stream()
-                .map(it ->
-                        new Line(
-                                (Long) result.get(0).get("LINE_ID"),
-                                (String) result.get(0).get("LINE_NAME")
-                        ))
-                .collect(Collectors.toList());
+        return result.stream().map(
+                    mapObj -> new Line(
+                        (Long) mapObj.get("LINE_ID"),
+                        (String) mapObj.get("LINE_NAME"))
+                )
+                .collect(toList());
     }
 
     private boolean hasLine(List<Map<String, Object>> result) {

--- a/src/main/java/atdd/path/domain/FavoritePath.java
+++ b/src/main/java/atdd/path/domain/FavoritePath.java
@@ -1,5 +1,7 @@
 package atdd.path.domain;
 
+import java.util.Objects;
+
 public class FavoritePath {
 
     private Long id;
@@ -40,6 +42,22 @@ public class FavoritePath {
 
     public Long getTargetStationId() {
         return targetStation.getId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FavoritePath favoritePath = (FavoritePath) o;
+        return Objects.equals(id, favoritePath.id) &&
+                Objects.equals(member, favoritePath.member) &&
+                Objects.equals(sourceStation, favoritePath.sourceStation) &&
+                Objects.equals(targetStation, favoritePath.targetStation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, member, sourceStation, targetStation);
     }
 
 }

--- a/src/main/java/atdd/path/domain/FavoritePath.java
+++ b/src/main/java/atdd/path/domain/FavoritePath.java
@@ -30,8 +30,16 @@ public class FavoritePath {
         return sourceStation;
     }
 
+    public Long getSourceStationId() {
+        return sourceStation.getId();
+    }
+
     public Station getTargetStation() {
         return targetStation;
+    }
+
+    public Long getTargetStationId() {
+        return targetStation.getId();
     }
 
 }

--- a/src/main/java/atdd/path/domain/FavoritePath.java
+++ b/src/main/java/atdd/path/domain/FavoritePath.java
@@ -3,17 +3,27 @@ package atdd.path.domain;
 public class FavoritePath {
 
     private Long id;
+    private Member member;
     private Station sourceStation;
     private Station targetStation;
 
-    public FavoritePath(Long id, Station sourceStation, Station targetStation) {
+    public FavoritePath(Member member, Station sourceStation, Station targetStation) {
+        this(null, member, sourceStation, targetStation);
+    }
+
+    public FavoritePath(Long id, Member member, Station sourceStation, Station targetStation) {
         this.id = id;
+        this.member = member;
         this.sourceStation = sourceStation;
         this.targetStation = targetStation;
     }
 
     public Long getId() {
         return id;
+    }
+
+    public Member getMember() {
+        return member;
     }
 
     public Station getSourceStation() {

--- a/src/main/java/atdd/path/domain/FavoritePath.java
+++ b/src/main/java/atdd/path/domain/FavoritePath.java
@@ -1,0 +1,27 @@
+package atdd.path.domain;
+
+public class FavoritePath {
+
+    private Long id;
+    private Station sourceStation;
+    private Station targetStation;
+
+    public FavoritePath(Long id, Station sourceStation, Station targetStation) {
+        this.id = id;
+        this.sourceStation = sourceStation;
+        this.targetStation = targetStation;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Station getSourceStation() {
+        return sourceStation;
+    }
+
+    public Station getTargetStation() {
+        return targetStation;
+    }
+
+}

--- a/src/main/java/atdd/path/domain/FavoriteStation.java
+++ b/src/main/java/atdd/path/domain/FavoriteStation.java
@@ -1,0 +1,21 @@
+package atdd.path.domain;
+
+public class FavoriteStation {
+
+    private Long id;
+    private Station station;
+
+    public FavoriteStation(Long id, Station station) {
+        this.id = id;
+        this.station = station;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Station getStation() {
+        return station;
+    }
+
+}

--- a/src/main/java/atdd/path/domain/FavoriteStation.java
+++ b/src/main/java/atdd/path/domain/FavoriteStation.java
@@ -24,8 +24,16 @@ public class FavoriteStation {
         return member;
     }
 
+    public Long getMemberId() {
+        return member.getId();
+    }
+
     public Station getStation() {
         return station;
+    }
+
+    public Long getStationId() {
+        return station.getId();
     }
 
 }

--- a/src/main/java/atdd/path/domain/FavoriteStation.java
+++ b/src/main/java/atdd/path/domain/FavoriteStation.java
@@ -1,5 +1,7 @@
 package atdd.path.domain;
 
+import java.util.Objects;
+
 public class FavoriteStation {
 
     private Long id;
@@ -34,6 +36,21 @@ public class FavoriteStation {
 
     public Long getStationId() {
         return station.getId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FavoriteStation favoriteStation = (FavoriteStation) o;
+        return Objects.equals(id, favoriteStation.id) &&
+                Objects.equals(member, favoriteStation.member) &&
+                Objects.equals(station, favoriteStation.station);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, member, station);
     }
 
 }

--- a/src/main/java/atdd/path/domain/FavoriteStation.java
+++ b/src/main/java/atdd/path/domain/FavoriteStation.java
@@ -3,15 +3,25 @@ package atdd.path.domain;
 public class FavoriteStation {
 
     private Long id;
+    private Member member;
     private Station station;
 
-    public FavoriteStation(Long id, Station station) {
+    public FavoriteStation(Member member, Station station) {
+        this(null, member, station);
+    }
+
+    public FavoriteStation(Long id, Member member, Station station) {
         this.id = id;
+        this.member = member;
         this.station = station;
     }
 
     public Long getId() {
         return id;
+    }
+
+    public Member getMember() {
+        return member;
     }
 
     public Station getStation() {

--- a/src/main/java/atdd/path/domain/Graph.java
+++ b/src/main/java/atdd/path/domain/Graph.java
@@ -1,6 +1,7 @@
 package atdd.path.domain;
 
 import org.jgrapht.GraphPath;
+import org.jgrapht.alg.ConnectivityInspector;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.WeightedMultigraph;
@@ -21,6 +22,11 @@ public class Graph {
 
     public List<Station> getShortestDistancePath(Long startId, Long endId) {
         return getPathStations(makeGraph(lines), startId, endId);
+    }
+
+    public boolean isPathExists(Long startId, Long endId) {
+        ConnectivityInspector<Long, DefaultWeightedEdge> inspector = new ConnectivityInspector<>(makeGraph(lines));
+        return inspector.pathExists(startId, endId);
     }
 
     private WeightedMultigraph<Long, DefaultWeightedEdge> makeGraph(List<Line> lines) {
@@ -50,4 +56,5 @@ public class Graph {
                 .findFirst()
                 .orElseThrow(RuntimeException::new);
     }
+
 }

--- a/src/main/java/atdd/path/domain/Guest.java
+++ b/src/main/java/atdd/path/domain/Guest.java
@@ -1,0 +1,12 @@
+package atdd.path.domain;
+
+public class Guest extends Member {
+
+    public static final Member GUEST_MEMBER = new Guest();
+
+    @Override
+    public boolean isGuest() {
+        return true;
+    }
+
+}

--- a/src/main/java/atdd/path/domain/Member.java
+++ b/src/main/java/atdd/path/domain/Member.java
@@ -9,6 +9,8 @@ public class Member {
     private String name;
     private String password;
 
+    protected Member() {}
+
     public Member(Long id, String email, String name, String password) {
         this.id = id;
         this.email = email;
@@ -38,6 +40,10 @@ public class Member {
 
     public String getPassword() {
         return password;
+    }
+
+    public boolean isGuest() {
+        return false;
     }
 
     @Override

--- a/src/main/java/atdd/path/domain/Member.java
+++ b/src/main/java/atdd/path/domain/Member.java
@@ -1,6 +1,6 @@
 package atdd.path.domain;
 
-import java.util.StringJoiner;
+import java.util.Objects;
 
 public class Member {
 
@@ -41,13 +41,17 @@ public class Member {
     }
 
     @Override
-    public String toString() {
-        return new StringJoiner(", ", Member.class.getSimpleName() + "[", "]")
-                .add("id=" + id)
-                .add("email='" + email + "'")
-                .add("name='" + name + "'")
-                .add("password='" + password + "'")
-                .toString();
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(id, member.id) &&
+                Objects.equals(email, member.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, email);
     }
 
 }

--- a/src/main/java/atdd/path/domain/Station.java
+++ b/src/main/java/atdd/path/domain/Station.java
@@ -39,6 +39,10 @@ public class Station {
         return lines;
     }
 
+    public boolean isSameStation(Station anotherStation) {
+        return this.equals(anotherStation);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -41,4 +41,10 @@ public class FavoriteController {
         return ResponseEntity.ok(new FavoriteStationsResponseView(favorites));
     }
 
+    @DeleteMapping("/stations/{id}")
+    public ResponseEntity<Object> deleteFavoriteStation(@PathVariable("id") Long favoriteId) {
+        favoriteDao.deleteForStationById(favoriteId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -1,0 +1,30 @@
+package atdd.path.web;
+
+import atdd.path.application.dto.FavoriteStationResponseView;
+import atdd.path.application.resolver.LoginUser;
+import atdd.path.domain.FavoriteStation;
+import atdd.path.domain.Member;
+import atdd.path.domain.Station;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RequestMapping("/favorites")
+@RestController
+public class FavoriteController {
+
+    @PostMapping("/stations/{id}")
+    public ResponseEntity<FavoriteStationResponseView> createFavoriteStation(@PathVariable("id") Long stationId,
+                                                                             @LoginUser Member member) {
+
+        final FavoriteStation savedFavoriteStation = new FavoriteStation(1L, new Station(stationId, "강남역"));
+
+        return ResponseEntity.created(URI.create("/favorites/"+ savedFavoriteStation.getId()))
+                .body(new FavoriteStationResponseView(savedFavoriteStation));
+    }
+
+}

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -1,12 +1,16 @@
 package atdd.path.web;
 
 import atdd.path.application.FavoriteService;
+import atdd.path.application.GraphService;
+import atdd.path.application.dto.FavoritePathResponseView;
 import atdd.path.application.dto.FavoriteStationResponseView;
 import atdd.path.application.dto.FavoriteStationsResponseView;
 import atdd.path.application.resolver.LoginUser;
 import atdd.path.dao.FavoriteDao;
+import atdd.path.domain.FavoritePath;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
+import atdd.path.domain.Station;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,9 +24,12 @@ public class FavoriteController {
     private final FavoriteService favoriteService;
     private final FavoriteDao favoriteDao;
 
-    public FavoriteController(FavoriteService favoriteService, FavoriteDao favoriteDao) {
+    private final GraphService graphService;
+
+    public FavoriteController(FavoriteService favoriteService, FavoriteDao favoriteDao, GraphService graphService) {
         this.favoriteService = favoriteService;
         this.favoriteDao = favoriteDao;
+        this.graphService = graphService;
     }
 
     @PostMapping("/stations/{id}")
@@ -45,6 +52,18 @@ public class FavoriteController {
     public ResponseEntity<Object> deleteFavoriteStation(@PathVariable("id") Long favoriteId) {
         favoriteDao.deleteForStationById(favoriteId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/paths")
+    public ResponseEntity<FavoritePathResponseView> createFavoritePath(@RequestParam Long startId,
+                                                                          @RequestParam Long endId,
+                                                                          @LoginUser Member member) {
+
+        final FavoritePath savedFavoritePath = favoriteService.saveFavoritePath(startId, endId, member);
+        final List<Station> stations = graphService.findPath(savedFavoritePath);
+
+        return ResponseEntity.created(URI.create("/favorites/"+ savedFavoritePath.getId()))
+                .body(new FavoritePathResponseView(savedFavoritePath, stations));
     }
 
 }

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -3,6 +3,7 @@ package atdd.path.web;
 import atdd.path.application.FavoriteService;
 import atdd.path.application.GraphService;
 import atdd.path.application.dto.FavoritePathResponseView;
+import atdd.path.application.dto.FavoritePathsResponseView;
 import atdd.path.application.dto.FavoriteStationResponseView;
 import atdd.path.application.dto.FavoriteStationsResponseView;
 import atdd.path.application.resolver.LoginUser;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @RequestMapping("/favorites")
 @RestController
@@ -64,6 +67,17 @@ public class FavoriteController {
 
         return ResponseEntity.created(URI.create("/favorites/"+ savedFavoritePath.getId()))
                 .body(new FavoritePathResponseView(savedFavoritePath, stations));
+    }
+
+    @GetMapping("/paths")
+    public ResponseEntity<FavoritePathsResponseView> findFavoritePath(@LoginUser Member member) {
+        final List<FavoritePath> findFavoritePaths = favoriteDao.findFavoritePath(member);
+
+        final List<FavoritePathResponseView> views = findFavoritePaths.stream()
+                .map(path -> new FavoritePathResponseView(path, graphService.findPath(path)))
+                .collect(toList());
+
+        return ResponseEntity.ok(new FavoritePathsResponseView(views));
     }
 
 }

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -59,7 +59,7 @@ public class FavoriteController {
                                                                           @RequestParam Long endId,
                                                                           @LoginUser Member member) {
 
-        final FavoritePath savedFavoritePath = favoriteService.saveFavoritePath(startId, endId, member);
+        final FavoritePath savedFavoritePath = favoriteService.saveForPath(member, startId, endId);
         final List<Station> stations = graphService.findPath(savedFavoritePath);
 
         return ResponseEntity.created(URI.create("/favorites/"+ savedFavoritePath.getId()))

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -80,4 +80,10 @@ public class FavoriteController {
         return ResponseEntity.ok(new FavoritePathsResponseView(views));
     }
 
+    @DeleteMapping("/paths/{id}")
+    public ResponseEntity<Object> deleteFavoritePaths(@PathVariable("id") Long favoriteId) {
+        favoriteDao.deleteForPathById(favoriteId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -7,7 +7,6 @@ import atdd.path.application.dto.FavoritePathsResponseView;
 import atdd.path.application.dto.FavoriteStationResponseView;
 import atdd.path.application.dto.FavoriteStationsResponseView;
 import atdd.path.application.resolver.LoginUser;
-import atdd.path.dao.FavoriteDao;
 import atdd.path.domain.FavoritePath;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
@@ -25,13 +24,10 @@ import static java.util.stream.Collectors.toList;
 public class FavoriteController {
 
     private final FavoriteService favoriteService;
-    private final FavoriteDao favoriteDao;
-
     private final GraphService graphService;
 
-    public FavoriteController(FavoriteService favoriteService, FavoriteDao favoriteDao, GraphService graphService) {
+    public FavoriteController(FavoriteService favoriteService, GraphService graphService) {
         this.favoriteService = favoriteService;
-        this.favoriteDao = favoriteDao;
         this.graphService = graphService;
     }
 
@@ -47,13 +43,13 @@ public class FavoriteController {
 
     @GetMapping("/stations")
     public ResponseEntity<FavoriteStationsResponseView> findFavoriteStations(@LoginUser Member member) {
-        final List<FavoriteStation> favorites = favoriteDao.findForStations(member);
+        final List<FavoriteStation> favorites = favoriteService.findForStations(member);
         return ResponseEntity.ok(new FavoriteStationsResponseView(favorites));
     }
 
     @DeleteMapping("/stations/{id}")
     public ResponseEntity<Object> deleteFavoriteStation(@PathVariable("id") Long favoriteId) {
-        favoriteDao.deleteForStationById(favoriteId);
+        favoriteService.deleteForStationById(favoriteId);
         return ResponseEntity.noContent().build();
     }
 
@@ -71,7 +67,7 @@ public class FavoriteController {
 
     @GetMapping("/paths")
     public ResponseEntity<FavoritePathsResponseView> findFavoritePath(@LoginUser Member member) {
-        final List<FavoritePath> findFavoritePaths = favoriteDao.findForPaths(member);
+        final List<FavoritePath> findFavoritePaths = favoriteService.findForPaths(member);
 
         final List<FavoritePathResponseView> views = findFavoritePaths.stream()
                 .map(path -> new FavoritePathResponseView(path, graphService.findPath(path)))
@@ -82,7 +78,7 @@ public class FavoriteController {
 
     @DeleteMapping("/paths/{id}")
     public ResponseEntity<Object> deleteFavoritePaths(@PathVariable("id") Long favoriteId) {
-        favoriteDao.deleteForPathById(favoriteId);
+        favoriteService.deleteForPathById(favoriteId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -37,7 +37,7 @@ public class FavoriteController {
 
     @GetMapping("/stations")
     public ResponseEntity<FavoriteStationsResponseView> findFavoriteStations(@LoginUser Member member) {
-        final List<FavoriteStation> favorites = favoriteDao.findForStations(member.getId());
+        final List<FavoriteStation> favorites = favoriteDao.findForStations(member);
         return ResponseEntity.ok(new FavoriteStationsResponseView(favorites));
     }
 

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -2,25 +2,27 @@ package atdd.path.web;
 
 import atdd.path.application.FavoriteService;
 import atdd.path.application.dto.FavoriteStationResponseView;
+import atdd.path.application.dto.FavoriteStationsResponseView;
 import atdd.path.application.resolver.LoginUser;
+import atdd.path.dao.FavoriteDao;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RequestMapping("/favorites")
 @RestController
 public class FavoriteController {
 
     private final FavoriteService favoriteService;
+    private final FavoriteDao favoriteDao;
 
-    public FavoriteController(FavoriteService favoriteService) {
+    public FavoriteController(FavoriteService favoriteService, FavoriteDao favoriteDao) {
         this.favoriteService = favoriteService;
+        this.favoriteDao = favoriteDao;
     }
 
     @PostMapping("/stations/{id}")
@@ -31,6 +33,12 @@ public class FavoriteController {
 
         return ResponseEntity.created(URI.create("/favorites/"+ savedFavoriteStation.getId()))
                 .body(new FavoriteStationResponseView(savedFavoriteStation));
+    }
+
+    @GetMapping("/stations")
+    public ResponseEntity<FavoriteStationsResponseView> findFavoriteStations(@LoginUser Member member) {
+        final List<FavoriteStation> favorites = favoriteDao.findForStations(member.getId());
+        return ResponseEntity.ok(new FavoriteStationsResponseView(favorites));
     }
 
 }

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -1,10 +1,10 @@
 package atdd.path.web;
 
+import atdd.path.application.FavoriteService;
 import atdd.path.application.dto.FavoriteStationResponseView;
 import atdd.path.application.resolver.LoginUser;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
-import atdd.path.domain.Station;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,11 +17,17 @@ import java.net.URI;
 @RestController
 public class FavoriteController {
 
+    private final FavoriteService favoriteService;
+
+    public FavoriteController(FavoriteService favoriteService) {
+        this.favoriteService = favoriteService;
+    }
+
     @PostMapping("/stations/{id}")
     public ResponseEntity<FavoriteStationResponseView> createFavoriteStation(@PathVariable("id") Long stationId,
                                                                              @LoginUser Member member) {
 
-        final FavoriteStation savedFavoriteStation = new FavoriteStation(1L, new Station(stationId, "강남역"));
+        final FavoriteStation savedFavoriteStation = favoriteService.saveForStation(member, stationId);
 
         return ResponseEntity.created(URI.create("/favorites/"+ savedFavoriteStation.getId()))
                 .body(new FavoriteStationResponseView(savedFavoriteStation));

--- a/src/main/java/atdd/path/web/FavoriteController.java
+++ b/src/main/java/atdd/path/web/FavoriteController.java
@@ -71,7 +71,7 @@ public class FavoriteController {
 
     @GetMapping("/paths")
     public ResponseEntity<FavoritePathsResponseView> findFavoritePath(@LoginUser Member member) {
-        final List<FavoritePath> findFavoritePaths = favoriteDao.findFavoritePath(member);
+        final List<FavoritePath> findFavoritePaths = favoriteDao.findForPaths(member);
 
         final List<FavoritePathResponseView> views = findFavoritePaths.stream()
                 .map(path -> new FavoritePathResponseView(path, graphService.findPath(path)))

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -33,3 +33,20 @@ create table if not exists MEMBER
     password varchar(20) not null,
     primary key(id)
 );
+
+create table if not exists FAVORITE_STATION
+(
+    id bigint auto_increment not null,
+    member_id bigint not null,
+    station_id bigint not null,
+    primary key(id)
+);
+
+create table if not exists FAVORITE_PATH
+(
+    id bigint auto_increment not null,
+    member_id bigint not null,
+    source_station_id bigint not null,
+    target_station_id bigint not null,
+    primary key(id)
+);

--- a/src/test/java/atdd/path/AbstractHttpTest.java
+++ b/src/test/java/atdd/path/AbstractHttpTest.java
@@ -1,0 +1,70 @@
+package atdd.path;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public abstract class AbstractHttpTest {
+
+    public WebTestClient webTestClient;
+
+    public AbstractHttpTest(WebTestClient webTestClient) {
+        this.webTestClient = webTestClient;
+    }
+
+    protected <T> EntityExchangeResult<T> createRequest(Class<T> classT, String uri, String inputJson) {
+        return webTestClient.post().uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(inputJson), String.class)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectHeader().exists("Location")
+                .expectBody(classT)
+                .returnResult();
+    }
+
+    protected <T> EntityExchangeResult<T> createRequestWithToken(Class<T> classT, String uri, String token) {
+        return webTestClient.post().uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectHeader().exists("Location")
+                .expectBody(classT)
+                .returnResult();
+    }
+
+    protected <T> EntityExchangeResult<T> findRequest(Class<T> classT, String uri) {
+        return webTestClient.get().uri(uri)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(classT)
+                .returnResult();
+    }
+
+    protected <T> EntityExchangeResult<List<T>> findRequestList(Class<T> classT, String uri) {
+        return webTestClient.get().uri(uri)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(classT)
+                .returnResult();
+    }
+
+    protected <T> EntityExchangeResult<T> findRequestWithToken(Class<T> classT, String uri, String token) {
+        return webTestClient.get().uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(classT)
+                .returnResult();
+    }
+
+}

--- a/src/test/java/atdd/path/TestConstant.java
+++ b/src/test/java/atdd/path/TestConstant.java
@@ -92,8 +92,8 @@ public class TestConstant {
     public static final Long MEMBER_ID = 1L;
 
     public static final Long FAVORITE_STATION_ID = 1L;
-    public static final Long FAVORITE_STATION_ID_2 = 2L;
-    public static final Long FAVORITE_STATION_ID_3 = 3L;
+
+    public static final Long FAVORITE_PATH_ID = 1L;
 
     public static Station TEST_STATION = new Station(STATION_ID, STATION_NAME);
     public static Station TEST_STATION_2 = new Station(STATION_ID_2, STATION_NAME_2);
@@ -163,6 +163,8 @@ public class TestConstant {
 
     // 지하철역 즐겨찾기
     public static FavoriteStation TEST_FAVORITE_STATION = new FavoriteStation(FAVORITE_STATION_ID, TEST_STATION);
-    public static FavoriteStation TEST_FAVORITE_STATION_2 = new FavoriteStation(FAVORITE_STATION_ID_2, TEST_STATION_2);
-    public static FavoriteStation TEST_FAVORITE_STATION_3 = new FavoriteStation(FAVORITE_STATION_ID_3, TEST_STATION_3);
+
+    // 경로 즐겨찾기
+    public static FavoritePath TEST_FAVORITE_PATH = new FavoritePath(FAVORITE_PATH_ID, TEST_STATION, TEST_STATION_4);
+
 }

--- a/src/test/java/atdd/path/TestConstant.java
+++ b/src/test/java/atdd/path/TestConstant.java
@@ -1,9 +1,6 @@
 package atdd.path;
 
-import atdd.path.domain.Edge;
-import atdd.path.domain.Line;
-import atdd.path.domain.Member;
-import atdd.path.domain.Station;
+import atdd.path.domain.*;
 import org.assertj.core.util.Lists;
 
 import java.time.LocalTime;
@@ -92,6 +89,12 @@ public class TestConstant {
     public static final Long EDGE_ID_22 = 22L;
     public static final Long EDGE_ID_23 = 23L;
 
+    public static final Long MEMBER_ID = 1L;
+
+    public static final Long FAVORITE_STATION_ID = 1L;
+    public static final Long FAVORITE_STATION_ID_2 = 2L;
+    public static final Long FAVORITE_STATION_ID_3 = 3L;
+
     public static Station TEST_STATION = new Station(STATION_ID, STATION_NAME);
     public static Station TEST_STATION_2 = new Station(STATION_ID_2, STATION_NAME_2);
     public static Station TEST_STATION_3 = new Station(STATION_ID_3, STATION_NAME_3);
@@ -156,5 +159,10 @@ public class TestConstant {
     public static final String TEST_MEMBER_NAME = "개발자";
     public static final String TEST_MEMBER_PASSWORD = "1234";
 
-    public static final Member TEST_MEMBER = new Member(TEST_MEMBER_EMAIL, TEST_MEMBER_NAME, TEST_MEMBER_PASSWORD);
+    public static final Member TEST_MEMBER = new Member(MEMBER_ID, TEST_MEMBER_EMAIL, TEST_MEMBER_NAME, TEST_MEMBER_PASSWORD);
+
+    // 지하철역 즐겨찾기
+    public static FavoriteStation TEST_FAVORITE_STATION = new FavoriteStation(FAVORITE_STATION_ID, TEST_STATION);
+    public static FavoriteStation TEST_FAVORITE_STATION_2 = new FavoriteStation(FAVORITE_STATION_ID_2, TEST_STATION_2);
+    public static FavoriteStation TEST_FAVORITE_STATION_3 = new FavoriteStation(FAVORITE_STATION_ID_3, TEST_STATION_3);
 }

--- a/src/test/java/atdd/path/TestConstant.java
+++ b/src/test/java/atdd/path/TestConstant.java
@@ -6,6 +6,17 @@ import org.assertj.core.util.Lists;
 import java.time.LocalTime;
 
 public class TestConstant {
+    public static final String STATION_URL = "/stations";
+    public static final String LINE_URL = "/lines";
+    public static final String EDGE_URL = "/edges";
+    public static final String PATH_URL = "/paths";
+
+    public static final String MEMBER_URL = "/members";
+    public static final String LOGIN_URL = "/login";
+
+    public static final String FAVORITES_STATIONS_URL = "/favorites/stations";
+    public static final String FAVORITES_PATH_URL = "/favorites/paths";
+
     public static final Long STATION_ID = 1L;
     public static final Long STATION_ID_2 = 2L;
     public static final Long STATION_ID_3 = 3L;

--- a/src/test/java/atdd/path/TestConstant.java
+++ b/src/test/java/atdd/path/TestConstant.java
@@ -165,6 +165,6 @@ public class TestConstant {
     public static FavoriteStation TEST_FAVORITE_STATION = new FavoriteStation(FAVORITE_STATION_ID, TEST_MEMBER, TEST_STATION);
 
     // 경로 즐겨찾기
-    public static FavoritePath TEST_FAVORITE_PATH = new FavoritePath(FAVORITE_PATH_ID, TEST_STATION, TEST_STATION_4);
+    public static FavoritePath TEST_FAVORITE_PATH = new FavoritePath(FAVORITE_PATH_ID, TEST_MEMBER, TEST_STATION, TEST_STATION_4);
 
 }

--- a/src/test/java/atdd/path/TestConstant.java
+++ b/src/test/java/atdd/path/TestConstant.java
@@ -162,7 +162,7 @@ public class TestConstant {
     public static final Member TEST_MEMBER = new Member(MEMBER_ID, TEST_MEMBER_EMAIL, TEST_MEMBER_NAME, TEST_MEMBER_PASSWORD);
 
     // 지하철역 즐겨찾기
-    public static FavoriteStation TEST_FAVORITE_STATION = new FavoriteStation(FAVORITE_STATION_ID, TEST_STATION);
+    public static FavoriteStation TEST_FAVORITE_STATION = new FavoriteStation(FAVORITE_STATION_ID, TEST_MEMBER, TEST_STATION);
 
     // 경로 즐겨찾기
     public static FavoritePath TEST_FAVORITE_PATH = new FavoritePath(FAVORITE_PATH_ID, TEST_STATION, TEST_STATION_4);

--- a/src/test/java/atdd/path/application/FavoriteServiceTest.java
+++ b/src/test/java/atdd/path/application/FavoriteServiceTest.java
@@ -2,6 +2,7 @@ package atdd.path.application;
 
 import atdd.path.dao.FavoriteDao;
 import atdd.path.dao.StationDao;
+import atdd.path.domain.FavoritePath;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Station;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,23 @@ class FavoriteServiceTest {
         assertThat(favoriteStation).isNotNull();
         assertThat(station).isNotNull();
         assertThat(station.getName()).isEqualTo(STATION_NAME);
+    }
+
+    @DisplayName("경로 즐겨찾기 등록을 해야한다")
+    @Test
+    public void mustSaveForPath() {
+        given(stationDao.findById(STATION_ID)).willReturn(TEST_STATION);
+        given(stationDao.findById(STATION_ID_4)).willReturn(TEST_STATION_4);
+        given(favoriteDao.saveForPath(any())).willReturn(TEST_FAVORITE_PATH);
+
+        FavoritePath favoritePath = favoriteService.saveForPath(TEST_MEMBER, STATION_ID, STATION_ID_4);
+        Station sourceStation = favoritePath.getSourceStation();
+        Station targetStation = favoritePath.getTargetStation();
+
+        assertThat(sourceStation).isNotNull();
+        assertThat(sourceStation.getName()).isEqualTo(STATION_NAME);
+        assertThat(targetStation).isNotNull();
+        assertThat(targetStation.getName()).isEqualTo(STATION_NAME_4);
     }
 
 }

--- a/src/test/java/atdd/path/application/FavoriteServiceTest.java
+++ b/src/test/java/atdd/path/application/FavoriteServiceTest.java
@@ -1,0 +1,49 @@
+package atdd.path.application;
+
+import atdd.path.dao.FavoriteDao;
+import atdd.path.dao.StationDao;
+import atdd.path.domain.FavoriteStation;
+import atdd.path.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static atdd.path.TestConstant.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(classes = FavoriteService.class)
+class FavoriteServiceTest {
+
+    @MockBean
+    private FavoriteDao favoriteDao;
+
+    @MockBean
+    private StationDao stationDao;
+
+    private FavoriteService favoriteService;
+
+    @BeforeEach
+    void setUp() {
+        this.favoriteService = new FavoriteService(favoriteDao, stationDao);
+    }
+
+    @DisplayName("지하철역 즐겨찾기 등록을 해야한다")
+    @Test
+    public void mustSaveForStation() {
+        given(stationDao.findById(anyLong())).willReturn(TEST_STATION);
+        given(favoriteDao.saveForStation(any(), any())).willReturn(TEST_FAVORITE_STATION);
+
+        FavoriteStation favoriteStation = favoriteService.saveForStation(TEST_MEMBER, STATION_ID);
+        Station station = favoriteStation.getStation();
+
+        assertThat(favoriteStation).isNotNull();
+        assertThat(station).isNotNull();
+        assertThat(station.getName()).isEqualTo(STATION_NAME);
+    }
+
+}

--- a/src/test/java/atdd/path/application/FavoriteServiceTest.java
+++ b/src/test/java/atdd/path/application/FavoriteServiceTest.java
@@ -1,5 +1,6 @@
 package atdd.path.application;
 
+import atdd.path.application.exception.ConflictException;
 import atdd.path.dao.FavoriteDao;
 import atdd.path.dao.StationDao;
 import atdd.path.domain.FavoritePath;
@@ -14,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -59,6 +61,19 @@ class FavoriteServiceTest {
         assertThat(sourceStation.getName()).isEqualTo(STATION_NAME);
         assertThat(targetStation).isNotNull();
         assertThat(targetStation.getName()).isEqualTo(STATION_NAME_4);
+    }
+
+    @DisplayName("경로 즐겨찾기 등록 시 같은 역인지 확인해야 한다")
+    @Test
+    void mustCheckSameStation() {
+        given(stationDao.findById(STATION_ID)).willReturn(TEST_STATION);
+        given(stationDao.findById(STATION_ID)).willReturn(TEST_STATION);
+
+        assertThrows(
+                ConflictException.class,
+                () ->  favoriteService.saveForPath(TEST_MEMBER, STATION_ID, STATION_ID),
+                "same station conflict"
+        );
     }
 
 }

--- a/src/test/java/atdd/path/application/FavoriteServiceTest.java
+++ b/src/test/java/atdd/path/application/FavoriteServiceTest.java
@@ -5,11 +5,12 @@ import atdd.path.dao.StationDao;
 import atdd.path.domain.FavoritePath;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Station;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,25 +18,21 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
-@SpringBootTest(classes = FavoriteService.class)
+@ExtendWith(MockitoExtension.class)
 class FavoriteServiceTest {
 
-    @MockBean
-    private FavoriteDao favoriteDao;
-
-    @MockBean
-    private StationDao stationDao;
-
+    @InjectMocks
     private FavoriteService favoriteService;
 
-    @BeforeEach
-    void setUp() {
-        this.favoriteService = new FavoriteService(favoriteDao, stationDao);
-    }
+    @Mock
+    private FavoriteDao favoriteDao;
 
-    @DisplayName("지하철역 즐겨찾기 등록을 해야한다")
+    @Mock
+    private StationDao stationDao;
+
+    @DisplayName("지하철역 즐겨찾기 등록을 해야 한다")
     @Test
-    public void mustSaveForStation() {
+    void mustSaveForStation() {
         given(stationDao.findById(anyLong())).willReturn(TEST_STATION);
         given(favoriteDao.saveForStation(any())).willReturn(TEST_FAVORITE_STATION);
 
@@ -47,9 +44,9 @@ class FavoriteServiceTest {
         assertThat(station.getName()).isEqualTo(STATION_NAME);
     }
 
-    @DisplayName("경로 즐겨찾기 등록을 해야한다")
+    @DisplayName("경로 즐겨찾기 등록을 해야 한다")
     @Test
-    public void mustSaveForPath() {
+    void mustSaveForPath() {
         given(stationDao.findById(STATION_ID)).willReturn(TEST_STATION);
         given(stationDao.findById(STATION_ID_4)).willReturn(TEST_STATION_4);
         given(favoriteDao.saveForPath(any())).willReturn(TEST_FAVORITE_PATH);

--- a/src/test/java/atdd/path/application/FavoriteServiceTest.java
+++ b/src/test/java/atdd/path/application/FavoriteServiceTest.java
@@ -36,7 +36,7 @@ class FavoriteServiceTest {
     @Test
     public void mustSaveForStation() {
         given(stationDao.findById(anyLong())).willReturn(TEST_STATION);
-        given(favoriteDao.saveForStation(any(), any())).willReturn(TEST_FAVORITE_STATION);
+        given(favoriteDao.saveForStation(any())).willReturn(TEST_FAVORITE_STATION);
 
         FavoriteStation favoriteStation = favoriteService.saveForStation(TEST_MEMBER, STATION_ID);
         Station station = favoriteStation.getStation();

--- a/src/test/java/atdd/path/application/interceptor/LoginInterceptorTest.java
+++ b/src/test/java/atdd/path/application/interceptor/LoginInterceptorTest.java
@@ -1,0 +1,66 @@
+package atdd.path.application.interceptor;
+
+import atdd.path.application.provider.JwtTokenProvider;
+import atdd.path.dao.MemberDao;
+import atdd.path.web.MemberController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static atdd.path.TestConstant.TEST_MEMBER;
+import static atdd.path.TestConstant.TEST_MEMBER_EMAIL;
+import static atdd.path.application.provider.JwtTokenProvider.TOKEN_TYPE;
+import static java.util.Optional.of;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import({JwtTokenProvider.class})
+@WebMvcTest(MemberController.class)
+class LoginInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private MemberDao memberDao;
+
+    @DisplayName("LoginInterceptor 를 통과 할 수 있다")
+    @Test
+    void beAbleToPassLoginInterceptor() throws Exception {
+        given(memberDao.findByEmail(TEST_MEMBER_EMAIL)).willReturn(of(TEST_MEMBER));
+
+        String token = jwtTokenProvider.createToken(TEST_MEMBER_EMAIL);
+
+        mockMvc.perform(get("/members/me")
+                .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + " " + token)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(TEST_MEMBER_EMAIL));
+    }
+
+    @DisplayName("LoginInterceptor 를 통과 할 수 없다")
+    @Test
+    void beAbleToBlockLoginInterceptor() throws Exception {
+        String token = jwtTokenProvider.createToken(TEST_MEMBER_EMAIL);
+
+        mockMvc.perform(get("/members/me")
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+}

--- a/src/test/java/atdd/path/application/provider/JwtTokenProviderTest.java
+++ b/src/test/java/atdd/path/application/provider/JwtTokenProviderTest.java
@@ -1,0 +1,72 @@
+package atdd.path.application.provider;
+
+import atdd.path.application.exception.InvalidJwtAuthenticationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StringUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static atdd.path.TestConstant.TEST_MEMBER_EMAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles("test")
+@SpringBootTest(classes = JwtTokenProvider.class)
+class JwtTokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Value("${spring.security.jwt.token.expire-length}")
+    private long validityInMilliseconds;
+
+    @DisplayName("토큰을 생성 할 수 있다")
+    @Test
+    void beAbleToCreateToken() {
+        String token = jwtTokenProvider.createToken(TEST_MEMBER_EMAIL);
+        String[] tokens = (StringUtils.isEmpty(token)) ? null : token.split("\\.");
+
+        assertThat(tokens).isNotNull();
+        assertThat(tokens.length).isEqualTo(3);
+        assertThat(tokens[0]).isEqualTo("eyJhbGciOiJIUzI1NiJ9"); // HS256
+    }
+
+    @DisplayName("토큰 유효성 검사를 성공 할 수 있다")
+    @Test
+    void beAbleToValidateTokenSuccessful() {
+        String token = jwtTokenProvider.createToken(TEST_MEMBER_EMAIL);
+
+        boolean isValidateToken = jwtTokenProvider.validateToken(token);
+
+        assertThat(isValidateToken).isTrue();
+    }
+
+    @DisplayName("토큰 유효기간이 만료될 수 있다")
+    @Test
+    void beAbleToValidateTokenExpire() throws InterruptedException {
+        String token = jwtTokenProvider.createToken(TEST_MEMBER_EMAIL);
+
+        TimeUnit.MILLISECONDS.sleep(validityInMilliseconds);
+
+        assertThrows(
+                InvalidJwtAuthenticationException.class,
+                () -> jwtTokenProvider.validateToken(token),
+                "Expired or invalid JWT token"
+        );
+    }
+
+    @DisplayName("토큰으로 이메일 주소를 가져올 수 있다")
+    @Test
+    void beAbleToExtractEmailFromToken() {
+        String token = jwtTokenProvider.createToken(TEST_MEMBER_EMAIL);
+        String email = jwtTokenProvider.getUserEmail(token);
+
+        assertThat(email).isEqualTo(TEST_MEMBER_EMAIL);
+    }
+
+}

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -49,7 +49,7 @@ class FavoriteDaoTest {
         Member savedMember = memberDao.save(TEST_MEMBER);
         Station savedStation = stationDao.save(TEST_STATION);
 
-        FavoriteStation savedFavoriteStation = favoriteDao.saveForStation(savedMember, savedStation);
+        FavoriteStation savedFavoriteStation = favoriteDao.saveForStation(new FavoriteStation(savedMember, savedStation));
         Station station = savedFavoriteStation.getStation();
 
         assertThat(savedFavoriteStation).isNotNull();
@@ -64,11 +64,11 @@ class FavoriteDaoTest {
         Station savedStation = stationDao.save(TEST_STATION);
         Station savedStation2 = stationDao.save(TEST_STATION_2);
         Station savedStation3 = stationDao.save(TEST_STATION_3);
-        favoriteDao.saveForStation(savedMember, savedStation);
-        favoriteDao.saveForStation(savedMember, savedStation2);
-        favoriteDao.saveForStation(savedMember, savedStation3);
+        favoriteDao.saveForStation(new FavoriteStation(savedMember, savedStation));
+        favoriteDao.saveForStation(new FavoriteStation(savedMember, savedStation2));
+        favoriteDao.saveForStation(new FavoriteStation(savedMember, savedStation3));
 
-        final List<FavoriteStation> favorites = favoriteDao.findForStations(savedMember.getId());
+        final List<FavoriteStation> favorites = favoriteDao.findForStations(savedMember);
 
         assertThat(favorites.size()).isEqualTo(3);
         assertThat(favorites).extracting("station.name")
@@ -80,7 +80,7 @@ class FavoriteDaoTest {
     void mustDeleteById() {
         Member savedMember = memberDao.save(TEST_MEMBER);
         Station savedStation = stationDao.save(TEST_STATION);
-        FavoriteStation savedFavorite = favoriteDao.saveForStation(savedMember, savedStation);
+        FavoriteStation savedFavorite = favoriteDao.saveForStation(new FavoriteStation(savedMember, savedStation));
 
         favoriteDao.deleteForStationById(savedFavorite.getId());
 

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
+import java.util.List;
 
 import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +41,7 @@ class FavoriteDaoTest {
         stationDao.setDataSource(dataSource);
     }
 
-    @DisplayName("지하철역 즐겨찾기 등록을 해야한다")
+    @DisplayName("지하철역 즐겨찾기 등록해야 한다")
     @Test
     public void mustSaveForStation() {
         Member savedMember = memberDao.save(TEST_MEMBER);
@@ -52,6 +53,24 @@ class FavoriteDaoTest {
         assertThat(savedFavoriteStation).isNotNull();
         assertThat(station).isNotNull();
         assertThat(station.getName()).isEqualTo(STATION_NAME);
+    }
+
+    @DisplayName("지하철역 즐겨찾기 목록을 조회해야 한다")
+    @Test
+    public void mustFindForStation() {
+        Member savedMember = memberDao.save(TEST_MEMBER);
+        Station savedStation = stationDao.save(TEST_STATION);
+        Station savedStation2 = stationDao.save(TEST_STATION_2);
+        Station savedStation3 = stationDao.save(TEST_STATION_3);
+        favoriteDao.saveForStation(savedMember, savedStation);
+        favoriteDao.saveForStation(savedMember, savedStation2);
+        favoriteDao.saveForStation(savedMember, savedStation3);
+
+        final List<FavoriteStation> favorites = favoriteDao.findForStations(savedMember.getId());
+
+        assertThat(favorites.size()).isEqualTo(3);
+        assertThat(favorites).extracting("station.name")
+                .containsExactly(STATION_NAME, STATION_NAME_2, STATION_NAME_3);
     }
 
 }

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -1,9 +1,7 @@
 package atdd.path.dao;
 
 import atdd.path.application.exception.NoDataException;
-import atdd.path.domain.FavoriteStation;
-import atdd.path.domain.Member;
-import atdd.path.domain.Station;
+import atdd.path.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,19 +26,27 @@ class FavoriteDaoTest {
     private DataSource dataSource;
 
     private FavoriteDao favoriteDao;
-    private MemberDao memberDao;
     private StationDao stationDao;
+    private LineDao lineDao;
+    private EdgeDao edgeDao;
+    private MemberDao memberDao;
 
     @BeforeEach
     void setUp() {
         favoriteDao = new FavoriteDao(jdbcTemplate);
         favoriteDao.setDataSource(dataSource);
 
-        memberDao = new MemberDao(jdbcTemplate);
-        memberDao.setDataSource(dataSource);
-
         stationDao = new StationDao(jdbcTemplate);
         stationDao.setDataSource(dataSource);
+
+        lineDao = new LineDao(jdbcTemplate);
+        lineDao.setDataSource(dataSource);
+
+        edgeDao = new EdgeDao(jdbcTemplate);
+        edgeDao.setDataSource(dataSource);
+
+        memberDao = new MemberDao(jdbcTemplate);
+        memberDao.setDataSource(dataSource);
     }
 
     @DisplayName("지하철역 즐겨찾기 등록해야 한다")
@@ -88,6 +94,34 @@ class FavoriteDaoTest {
                 NoDataException.class,
                 () -> favoriteDao.deleteForStationById(savedFavorite.getId())
         );
+    }
+
+    @DisplayName("경로를 즐겨찾기로 저장해야 한다")
+    @Test
+    void mustSaveFavoritePath() {
+        Station savedStation = stationDao.save(TEST_STATION);
+        Station savedStation2 = stationDao.save(TEST_STATION_2);
+        Station savedStation3 = stationDao.save(TEST_STATION_3);
+        Station savedStation4 = stationDao.save(TEST_STATION_4);
+
+        Line savedLine = lineDao.save(TEST_LINE);
+        int distance = 10;
+
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation, savedStation2, distance));
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation2, savedStation3, distance));
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation3, savedStation4, distance));
+
+        Member savedMember = memberDao.save(TEST_MEMBER);
+
+        FavoritePath favoritePath = new FavoritePath(savedMember, savedStation, savedStation4);
+        FavoritePath savedFavoritePath = favoriteDao.saveForPath(favoritePath);
+        Station sourceStation = savedFavoritePath.getSourceStation();
+        Station targetStation = savedFavoritePath.getTargetStation();
+
+        assertThat(sourceStation).isNotNull();
+        assertThat(sourceStation.getName()).isEqualTo(STATION_NAME);
+        assertThat(targetStation).isNotNull();
+        assertThat(targetStation.getName()).isEqualTo(STATION_NAME_4);
     }
 
 }

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -1,5 +1,6 @@
 package atdd.path.dao;
 
+import atdd.path.application.exception.NoDataException;
 import atdd.path.domain.FavoriteStation;
 import atdd.path.domain.Member;
 import atdd.path.domain.Station;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @JdbcTest
 class FavoriteDaoTest {
@@ -71,6 +73,21 @@ class FavoriteDaoTest {
         assertThat(favorites.size()).isEqualTo(3);
         assertThat(favorites).extracting("station.name")
                 .containsExactly(STATION_NAME, STATION_NAME_2, STATION_NAME_3);
+    }
+
+    @DisplayName("즐겨찾기 아이디로 즐겨찾기 한 지하철역을 삭제해야 한다")
+    @Test
+    void mustDeleteById() {
+        Member savedMember = memberDao.save(TEST_MEMBER);
+        Station savedStation = stationDao.save(TEST_STATION);
+        FavoriteStation savedFavorite = favoriteDao.saveForStation(savedMember, savedStation);
+
+        favoriteDao.deleteForStationById(savedFavorite.getId());
+
+        assertThrows(
+                NoDataException.class,
+                () -> favoriteDao.deleteForStationById(savedFavorite.getId())
+        );
     }
 
 }

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -1,0 +1,57 @@
+package atdd.path.dao;
+
+import atdd.path.domain.FavoriteStation;
+import atdd.path.domain.Member;
+import atdd.path.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+import static atdd.path.TestConstant.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+class FavoriteDaoTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private FavoriteDao favoriteDao;
+    private MemberDao memberDao;
+    private StationDao stationDao;
+
+    @BeforeEach
+    void setUp() {
+        favoriteDao = new FavoriteDao(jdbcTemplate);
+        favoriteDao.setDataSource(dataSource);
+
+        memberDao = new MemberDao(jdbcTemplate);
+        memberDao.setDataSource(dataSource);
+
+        stationDao = new StationDao(jdbcTemplate);
+        stationDao.setDataSource(dataSource);
+    }
+
+    @DisplayName("지하철역 즐겨찾기 등록을 해야한다")
+    @Test
+    public void mustSaveForStation() {
+        Member savedMember = memberDao.save(TEST_MEMBER);
+        Station savedStation = stationDao.save(TEST_STATION);
+
+        FavoriteStation savedFavoriteStation = favoriteDao.saveForStation(savedMember, savedStation);
+        Station station = savedFavoriteStation.getStation();
+
+        assertThat(savedFavoriteStation).isNotNull();
+        assertThat(station).isNotNull();
+        assertThat(station.getName()).isEqualTo(STATION_NAME);
+    }
+
+}

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -124,4 +124,33 @@ class FavoriteDaoTest {
         assertThat(targetStation.getName()).isEqualTo(STATION_NAME_4);
     }
 
+    @DisplayName("경로 즐겨찾기 목록을 조회해야 한다")
+    @Test
+    void mustFindFavoritePath() {
+        Station savedStation = stationDao.save(TEST_STATION);
+        Station savedStation2 = stationDao.save(TEST_STATION_2);
+        Station savedStation3 = stationDao.save(TEST_STATION_3);
+        Station savedStation4 = stationDao.save(TEST_STATION_4);
+
+        Line savedLine = lineDao.save(TEST_LINE);
+        int distance = 10;
+
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation, savedStation2, distance));
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation2, savedStation3, distance));
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation3, savedStation4, distance));
+
+        Member savedMember = memberDao.save(TEST_MEMBER);
+
+        favoriteDao.saveForPath(new FavoritePath(savedMember, savedStation, savedStation3));
+        favoriteDao.saveForPath(new FavoritePath(savedMember, savedStation2, savedStation4));
+        favoriteDao.saveForPath(new FavoritePath(savedMember, savedStation, savedStation4));
+
+        List<FavoritePath> favorites = favoriteDao.findForPaths(savedMember);
+
+        assertThat(favorites.size()).isEqualTo(3);
+        assertThat(favorites).extracting("sourceStation.name")
+                .containsExactly(STATION_NAME, STATION_NAME_2, STATION_NAME);
+
+    }
+
 }

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -83,7 +83,7 @@ class FavoriteDaoTest {
 
     @DisplayName("즐겨찾기 아이디로 즐겨찾기 한 지하철역을 삭제해야 한다")
     @Test
-    void mustDeleteById() {
+    void mustDeleteForStationById() {
         Member savedMember = memberDao.save(TEST_MEMBER);
         Station savedStation = stationDao.save(TEST_STATION);
         FavoriteStation savedFavorite = favoriteDao.saveForStation(new FavoriteStation(savedMember, savedStation));
@@ -98,7 +98,7 @@ class FavoriteDaoTest {
 
     @DisplayName("경로를 즐겨찾기로 저장해야 한다")
     @Test
-    void mustSaveFavoritePath() {
+    void mustSaveForPath() {
         Station savedStation = stationDao.save(TEST_STATION);
         Station savedStation2 = stationDao.save(TEST_STATION_2);
         Station savedStation3 = stationDao.save(TEST_STATION_3);
@@ -126,7 +126,7 @@ class FavoriteDaoTest {
 
     @DisplayName("경로 즐겨찾기 목록을 조회해야 한다")
     @Test
-    void mustFindFavoritePath() {
+    void mustFindForPath() {
         Station savedStation = stationDao.save(TEST_STATION);
         Station savedStation2 = stationDao.save(TEST_STATION_2);
         Station savedStation3 = stationDao.save(TEST_STATION_3);
@@ -151,6 +151,34 @@ class FavoriteDaoTest {
         assertThat(favorites).extracting("sourceStation.name")
                 .containsExactly(STATION_NAME, STATION_NAME_2, STATION_NAME);
 
+    }
+
+    @DisplayName("즐겨찾기 아이디로 즐겨찾기 한 지하철역을 삭제해야 한다")
+    @Test
+    void mustDeleteForPathById() {
+        Station savedStation = stationDao.save(TEST_STATION);
+        Station savedStation2 = stationDao.save(TEST_STATION_2);
+        Station savedStation3 = stationDao.save(TEST_STATION_3);
+        Station savedStation4 = stationDao.save(TEST_STATION_4);
+
+        Line savedLine = lineDao.save(TEST_LINE);
+        int distance = 10;
+
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation, savedStation2, distance));
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation2, savedStation3, distance));
+        edgeDao.save(savedLine.getId(), Edge.of(savedStation3, savedStation4, distance));
+
+        Member savedMember = memberDao.save(TEST_MEMBER);
+
+        final FavoritePath savedFavorite = favoriteDao.saveForPath(
+                new FavoritePath(savedMember, savedStation, savedStation3));
+
+        favoriteDao.deleteForPathById(savedFavorite.getId());
+
+        assertThrows(
+                NoDataException.class,
+                () -> favoriteDao.deleteForPathById(savedFavorite.getId())
+        );
     }
 
 }

--- a/src/test/java/atdd/path/dao/FavoriteDaoTest.java
+++ b/src/test/java/atdd/path/dao/FavoriteDaoTest.java
@@ -2,52 +2,37 @@ package atdd.path.dao;
 
 import atdd.path.application.exception.NoDataException;
 import atdd.path.domain.*;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
 import java.util.List;
 
 import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.context.annotation.FilterType.ANNOTATION;
 
-@JdbcTest
+@JdbcTest(includeFilters = @ComponentScan.Filter(type = ANNOTATION, classes = Repository.class))
 class FavoriteDaoTest {
 
     @Autowired
-    private JdbcTemplate jdbcTemplate;
+    private FavoriteDao favoriteDao;
 
     @Autowired
-    private DataSource dataSource;
-
-    private FavoriteDao favoriteDao;
     private StationDao stationDao;
+
+    @Autowired
     private LineDao lineDao;
+
+    @Autowired
     private EdgeDao edgeDao;
+
+    @Autowired
     private MemberDao memberDao;
-
-    @BeforeEach
-    void setUp() {
-        favoriteDao = new FavoriteDao(jdbcTemplate);
-        favoriteDao.setDataSource(dataSource);
-
-        stationDao = new StationDao(jdbcTemplate);
-        stationDao.setDataSource(dataSource);
-
-        lineDao = new LineDao(jdbcTemplate);
-        lineDao.setDataSource(dataSource);
-
-        edgeDao = new EdgeDao(jdbcTemplate);
-        edgeDao.setDataSource(dataSource);
-
-        memberDao = new MemberDao(jdbcTemplate);
-        memberDao.setDataSource(dataSource);
-    }
 
     @DisplayName("지하철역 즐겨찾기 등록해야 한다")
     @Test

--- a/src/test/java/atdd/path/domain/GraphTest.java
+++ b/src/test/java/atdd/path/domain/GraphTest.java
@@ -1,6 +1,7 @@
 package atdd.path.domain;
 
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -27,4 +28,14 @@ public class GraphTest {
         assertThat(result.get(0)).isEqualTo(TEST_STATION);
         assertThat(result.get(2)).isEqualTo(TEST_STATION_3);
     }
+
+    @DisplayName("시작점과 끝점이 연결된 선이 있는지 확인해야 한다")
+    @Test
+    void mustPathExists() {
+        Graph graph = new Graph(List.of(TEST_LINE));
+
+        boolean isConnect = graph.isPathExists(STATION_ID, STATION_ID_22);
+        assertThat(isConnect).isFalse();
+    }
+
 }

--- a/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
 
+    private final String FAVORITES_STATIONS_URL = "/favorites/stations";
+
     private MemberHttpTest memberHttpTest;
     private StationHttpTest stationHttpTest;
 
@@ -53,18 +55,19 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
         createForStationRequest(stationId2, token);
         createForStationRequest(stationId3, token);
 
-        webTestClient.get().uri("/favorites/stations")
+        webTestClient.get().uri(FAVORITES_STATIONS_URL)
                 .header(AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
                 .jsonPath("$.count").isEqualTo(3)
-                .jsonPath("$.stations[0].name").isEqualTo(STATION_NAME);
+                .jsonPath("$.favorites[0].id").isEqualTo(FAVORITE_STATION_ID)
+                .jsonPath("$.favorites[0].station.name").isEqualTo(STATION_NAME);
     }
 
     public EntityExchangeResult<FavoriteStationResponseView> createForStationRequest(Long stationId, String token) {
-        return webTestClient.post().uri("/favorites/stations/" + stationId)
+        return webTestClient.post().uri(FAVORITES_STATIONS_URL + "/" + stationId)
                 .header(AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isCreated()

--- a/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
@@ -23,7 +23,7 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
 
     @DisplayName("지하철역 즐겨찾기 등록을 할 수 있다")
     @Test
-    void beAbleToSaveFavoriteStation() {
+    void beAbleToSaveForStation() {
         Long stationId = stationHttpTest.createStation(STATION_NAME);
 
         memberHttpTest.createMemberRequest(TEST_MEMBER);

--- a/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
@@ -1,14 +1,16 @@
 package atdd.path.web;
 
 import atdd.path.AbstractAcceptanceTest;
+import atdd.path.application.dto.FavoriteStationResponseView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
 
-import static atdd.path.TestConstant.STATION_NAME;
-import static atdd.path.TestConstant.TEST_MEMBER;
+import static atdd.path.TestConstant.*;
 import static atdd.path.application.provider.JwtTokenProvider.AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
 
@@ -29,15 +31,47 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
         memberHttpTest.createMemberRequest(TEST_MEMBER);
         String token = memberHttpTest.loginMember(TEST_MEMBER);
 
-        webTestClient.post().uri("/favorites/stations/" + stationId)
+        EntityExchangeResult<FavoriteStationResponseView> result = createForStationRequest(stationId, token);
+        FavoriteStationResponseView view = result.getResponseBody();
+
+        assertThat(view).isNotNull();
+        assertThat(view.getId()).isEqualTo(FAVORITE_STATION_ID);
+        assertThat(view.getStation().getName()).isEqualTo(STATION_NAME);
+    }
+
+    @DisplayName("지하철역 즐겨찾기 목록을 조회 할 수 있다")
+    @Test
+    void beAbleToFindForStation() {
+        Long stationId = stationHttpTest.createStation(STATION_NAME);
+        Long stationId2 = stationHttpTest.createStation(STATION_NAME_2);
+        Long stationId3 = stationHttpTest.createStation(STATION_NAME_3);
+
+        memberHttpTest.createMemberRequest(TEST_MEMBER);
+        String token = memberHttpTest.loginMember(TEST_MEMBER);
+
+        createForStationRequest(stationId, token);
+        createForStationRequest(stationId2, token);
+        createForStationRequest(stationId3, token);
+
+        webTestClient.get().uri("/favorites/stations")
+                .header(AUTHORIZATION, token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.count").isEqualTo(3)
+                .jsonPath("$.stations[0].name").isEqualTo(STATION_NAME);
+    }
+
+    public EntityExchangeResult<FavoriteStationResponseView> createForStationRequest(Long stationId, String token) {
+        return webTestClient.post().uri("/favorites/stations/" + stationId)
                 .header(AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectHeader().exists("Location")
-                .expectBody()
-                .jsonPath("$.id").isNotEmpty()
-                .jsonPath("$.station.name").isEqualTo(STATION_NAME);
+                .expectBody(FavoriteStationResponseView.class)
+                .returnResult();
     }
 
 }

--- a/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
@@ -1,0 +1,43 @@
+package atdd.path.web;
+
+import atdd.path.AbstractAcceptanceTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static atdd.path.TestConstant.STATION_NAME;
+import static atdd.path.TestConstant.TEST_MEMBER;
+import static atdd.path.application.provider.JwtTokenProvider.AUTHORIZATION;
+
+public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
+
+    private MemberHttpTest memberHttpTest;
+    private StationHttpTest stationHttpTest;
+
+    @BeforeEach
+    void setUp() {
+        memberHttpTest = new MemberHttpTest(webTestClient);
+        stationHttpTest = new StationHttpTest(webTestClient);
+    }
+
+    @DisplayName("지하철역 즐겨찾기 등록을 할 수 있다")
+    @Test
+    void beAbleToSaveFavoriteStation() {
+        Long stationId = stationHttpTest.createStation(STATION_NAME);
+
+        memberHttpTest.createMemberRequest(TEST_MEMBER);
+        String token = memberHttpTest.loginMember(TEST_MEMBER);
+
+        webTestClient.post().uri("/favorites/stations/" + stationId)
+                .header(AUTHORIZATION, token)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectHeader().exists("Location")
+                .expectBody()
+                .jsonPath("$.id").isNotEmpty()
+                .jsonPath("$.station.name").isEqualTo(STATION_NAME);
+    }
+
+}

--- a/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
@@ -143,9 +143,9 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
 
         assertThat(view).isNotNull();
         assertThat(view.getCount()).isEqualTo(3);
-        assertThat(view.getFavorites())
-                .extracting("path[0].stations[0].name")
-                .containsExactly(STATION_NAME, STATION_NAME_2, STATION_NAME_3);
+        assertThat(view.getFavorites().get(0))
+                .extracting("path.startStationId", "path.endStationId")
+                .containsExactly(STATION_ID, STATION_ID_3);
     }
 
     private FavoriteStationResponseView createForStation(Long stationId, String token) {

--- a/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/FavoriteAcceptanceTest.java
@@ -5,11 +5,11 @@ import atdd.path.application.dto.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 
 import static atdd.path.TestConstant.*;
-import static atdd.path.application.provider.JwtTokenProvider.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
@@ -79,7 +79,7 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
         FavoriteStationResponseView createView = createForStation(stationId, token);
 
         webTestClient.delete().uri(FAVORITES_STATIONS_URL + "/" + createView.getId())
-                .header(AUTHORIZATION, token)
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isNoContent();
 
@@ -136,7 +136,7 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
         FavoritePathResponseView createView = createForPath(STATION_ID, STATION_ID_3, token);
 
         webTestClient.delete().uri(FAVORITES_PATH_URL + "/" + createView.getId())
-                .header(AUTHORIZATION, token)
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isNoContent();
 
@@ -199,7 +199,7 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
 
     private <T> EntityExchangeResult<T> createRequest(Class<T> classT, String uri, String token) {
         return webTestClient.post().uri(uri)
-                .header(AUTHORIZATION, token)
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -210,7 +210,7 @@ public class FavoriteAcceptanceTest extends AbstractAcceptanceTest {
 
     private <T> EntityExchangeResult<T> findRequest(Class<T> classT, String uri, String token) {
         return webTestClient.get().uri(uri)
-                .header(AUTHORIZATION, token)
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/atdd/path/web/FavoriteHttpTest.java
+++ b/src/test/java/atdd/path/web/FavoriteHttpTest.java
@@ -1,0 +1,57 @@
+package atdd.path.web;
+
+import atdd.path.AbstractHttpTest;
+import atdd.path.application.dto.FavoritePathResponseView;
+import atdd.path.application.dto.FavoritePathsResponseView;
+import atdd.path.application.dto.FavoriteStationResponseView;
+import atdd.path.application.dto.FavoriteStationsResponseView;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static atdd.path.TestConstant.FAVORITES_PATH_URL;
+import static atdd.path.TestConstant.FAVORITES_STATIONS_URL;
+
+public class FavoriteHttpTest extends AbstractHttpTest {
+
+    public FavoriteHttpTest(WebTestClient webTestClient) {
+        super(webTestClient);
+    }
+
+    public FavoriteStationResponseView createForStation(Long stationId, String token) {
+        EntityExchangeResult<FavoriteStationResponseView> result = createForStationRequest(stationId, token);
+        return result.getResponseBody();
+    }
+
+    public EntityExchangeResult<FavoriteStationResponseView> createForStationRequest(Long stationId, String token) {
+        return createRequestWithToken(FavoriteStationResponseView.class, FAVORITES_STATIONS_URL + "/" + stationId, token);
+    }
+
+    public FavoriteStationsResponseView findForStations(String token) {
+        EntityExchangeResult<FavoriteStationsResponseView> result = findForStationRequest(token);
+        return result.getResponseBody();
+    }
+
+    public EntityExchangeResult<FavoriteStationsResponseView> findForStationRequest(String token) {
+        return findRequestWithToken(FavoriteStationsResponseView.class, FAVORITES_STATIONS_URL, token);
+    }
+
+    public FavoritePathResponseView createForPath(Long startId, Long endId, String token) {
+        EntityExchangeResult<FavoritePathResponseView> result = createForPathRequest(startId, endId, token);
+        return result.getResponseBody();
+    }
+
+    public EntityExchangeResult<FavoritePathResponseView> createForPathRequest(Long startId, Long endId, String token) {
+        return createRequestWithToken(FavoritePathResponseView.class,
+                FAVORITES_PATH_URL + "?startId=" + startId + "&endId=" + endId, token);
+    }
+
+    public FavoritePathsResponseView findForPaths(String token) {
+        EntityExchangeResult<FavoritePathsResponseView> result = findForPathsRequest(token);
+        return result.getResponseBody();
+    }
+
+    public EntityExchangeResult<FavoritePathsResponseView> findForPathsRequest(String token) {
+        return findRequestWithToken(FavoritePathsResponseView.class, FAVORITES_PATH_URL, token);
+    }
+
+}

--- a/src/test/java/atdd/path/web/GraphAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/GraphAcceptanceTest.java
@@ -1,20 +1,24 @@
 package atdd.path.web;
 
 import atdd.path.AbstractAcceptanceTest;
+import atdd.path.application.dto.PathResponseView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 
 import static atdd.path.TestConstant.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GraphAcceptanceTest extends AbstractAcceptanceTest {
+
     private StationHttpTest stationHttpTest;
     private LineHttpTest lineHttpTest;
+    private GraphHttpTest graphHttpTest;
 
     @BeforeEach
     void setUp() {
         this.stationHttpTest = new StationHttpTest(webTestClient);
         this.lineHttpTest = new LineHttpTest(webTestClient);
+        this.graphHttpTest = new GraphHttpTest(webTestClient);
     }
 
     @Test
@@ -28,14 +32,12 @@ public class GraphAcceptanceTest extends AbstractAcceptanceTest {
         lineHttpTest.createEdgeRequest(lineId, stationId2, stationId3);
         lineHttpTest.createEdgeRequest(lineId, stationId3, stationId4);
 
-        webTestClient.get().uri("/paths?startId=" + stationId + "&endId=" + stationId4)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody()
-                .jsonPath("$.startStationId").isEqualTo(stationId)
-                .jsonPath("$.endStationId").isEqualTo(stationId4)
-                .jsonPath("$.stations.length()").isEqualTo(4);
+        PathResponseView view = graphHttpTest.findPath(stationId, stationId4);
+
+        assertThat(view).isNotNull();
+        assertThat(view.getStartStationId()).isEqualTo(STATION_ID);
+        assertThat(view.getEndStationId()).isEqualTo(STATION_ID_4);
+        assertThat(view.getStations().size()).isEqualTo(4);
     }
 
 }

--- a/src/test/java/atdd/path/web/GraphHttpTest.java
+++ b/src/test/java/atdd/path/web/GraphHttpTest.java
@@ -1,17 +1,16 @@
 package atdd.path.web;
 
-import atdd.path.AbstractAcceptanceTest;
+import atdd.path.AbstractHttpTest;
 import atdd.path.application.dto.PathResponseView;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-public class GraphHttpTest extends AbstractAcceptanceTest {
+import static atdd.path.TestConstant.PATH_URL;
 
-    public WebTestClient webTestClient;
+public class GraphHttpTest extends AbstractHttpTest {
 
     public GraphHttpTest(WebTestClient webTestClient) {
-        this.webTestClient = webTestClient;
+        super(webTestClient);
     }
 
     public PathResponseView findPath(Long startId, Long endId) {
@@ -20,12 +19,7 @@ public class GraphHttpTest extends AbstractAcceptanceTest {
     }
 
     public EntityExchangeResult<PathResponseView> findPathRequest(Long startId, Long endId) {
-        return webTestClient.get().uri("/paths?startId=" + startId + "&endId=" + endId)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody(PathResponseView.class)
-                .returnResult();
+        return findRequest(PathResponseView.class, PATH_URL + "?startId=" + startId + "&endId=" + endId);
     }
 
 }

--- a/src/test/java/atdd/path/web/GraphHttpTest.java
+++ b/src/test/java/atdd/path/web/GraphHttpTest.java
@@ -1,0 +1,31 @@
+package atdd.path.web;
+
+import atdd.path.AbstractAcceptanceTest;
+import atdd.path.application.dto.PathResponseView;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+public class GraphHttpTest extends AbstractAcceptanceTest {
+
+    public WebTestClient webTestClient;
+
+    public GraphHttpTest(WebTestClient webTestClient) {
+        this.webTestClient = webTestClient;
+    }
+
+    public PathResponseView findPath(Long startId, Long endId) {
+        EntityExchangeResult<PathResponseView> result = findPathRequest(startId, endId);
+        return result.getResponseBody();
+    }
+
+    public EntityExchangeResult<PathResponseView> findPathRequest(Long startId, Long endId) {
+        return webTestClient.get().uri("/paths?startId=" + startId + "&endId=" + endId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(PathResponseView.class)
+                .returnResult();
+    }
+
+}

--- a/src/test/java/atdd/path/web/LineAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/LineAcceptanceTest.java
@@ -14,8 +14,6 @@ import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineAcceptanceTest extends AbstractAcceptanceTest {
-    public static final String LINE_URL = "/lines";
-    public static final String EDGE_URL = "/edges";
 
     private StationHttpTest stationHttpTest;
     private LineHttpTest lineHttpTest;

--- a/src/test/java/atdd/path/web/LineHttpTest.java
+++ b/src/test/java/atdd/path/web/LineHttpTest.java
@@ -1,5 +1,6 @@
 package atdd.path.web;
 
+import atdd.path.AbstractHttpTest;
 import atdd.path.application.dto.LineResponseView;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
@@ -9,12 +10,12 @@ import reactor.core.publisher.Mono;
 import java.time.LocalTime;
 import java.util.List;
 
-public class LineHttpTest {
-    public static final String LINE_URL = "/lines";
-    public WebTestClient webTestClient;
+import static atdd.path.TestConstant.LINE_URL;
+
+public class LineHttpTest extends AbstractHttpTest {
 
     public LineHttpTest(WebTestClient webTestClient) {
-        this.webTestClient = webTestClient;
+        super(webTestClient);
     }
 
     public EntityExchangeResult<LineResponseView> createLineRequest(String lineName) {
@@ -23,32 +24,15 @@ public class LineHttpTest {
                 "\"endTime\":\"" + LocalTime.of(23, 30) + "\"," +
                 "\"interval\":\"" + 30 + "\"}";
 
-        return webTestClient.post().uri(LINE_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(inputJson), String.class)
-                .exchange()
-                .expectStatus().isCreated()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectHeader().exists("Location")
-                .expectBody(LineResponseView.class)
-                .returnResult();
+        return createRequest(LineResponseView.class, LINE_URL, inputJson);
     }
 
     public EntityExchangeResult<LineResponseView> retrieveLineRequest(String uri) {
-        return webTestClient.get().uri(uri)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(LineResponseView.class)
-                .returnResult();
+        return findRequest(LineResponseView.class, uri);
     }
 
     public EntityExchangeResult<List<LineResponseView>> showLinesRequest() {
-        return webTestClient.get().uri(LINE_URL)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBodyList(LineResponseView.class)
-                .returnResult();
+        return findRequestList(LineResponseView.class, LINE_URL);
     }
 
     public Long createLine(String lineName) {
@@ -66,7 +50,7 @@ public class LineHttpTest {
                 ",\"targetId\":" + stationId2 +
                 ",\"distance\":" + distance + "}";
 
-        return webTestClient.post().uri("/lines/" + lineId + "/edges")
+        return webTestClient.post().uri(LINE_URL + "/" + lineId + "/edges")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(Mono.just(inputJson), String.class)
                 .exchange()

--- a/src/test/java/atdd/path/web/MemberAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/MemberAcceptanceTest.java
@@ -5,10 +5,10 @@ import atdd.path.application.dto.MemberResponseView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import static atdd.path.TestConstant.*;
-import static atdd.path.application.provider.JwtTokenProvider.AUTHORIZATION;
 import static atdd.path.application.provider.JwtTokenProvider.TOKEN_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,7 +64,7 @@ public class MemberAcceptanceTest extends AbstractAcceptanceTest {
         String token = memberHttpTest.loginMember(TEST_MEMBER);
 
         webTestClient.get().uri("/members/me")
-                .header(AUTHORIZATION, token)
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/atdd/path/web/MemberAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/MemberAcceptanceTest.java
@@ -1,29 +1,30 @@
 package atdd.path.web;
 
 import atdd.path.AbstractAcceptanceTest;
-import atdd.path.application.dto.LoginResponseView;
 import atdd.path.application.dto.MemberResponseView;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.reactive.server.EntityExchangeResult;
-import reactor.core.publisher.Mono;
-
-import java.util.Map;
-import java.util.function.Supplier;
 
 import static atdd.path.TestConstant.*;
-import static atdd.path.TestUtils.jsonOf;
 import static atdd.path.application.provider.JwtTokenProvider.AUTHORIZATION;
 import static atdd.path.application.provider.JwtTokenProvider.TOKEN_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemberAcceptanceTest extends AbstractAcceptanceTest {
 
+    private MemberHttpTest memberHttpTest;
+
+    @BeforeEach
+    void setUp() {
+        memberHttpTest = new MemberHttpTest(webTestClient);
+    }
+
     @DisplayName("회원 가입을 할 수 있다")
     @Test
     void beAbleToJoin() {
-        MemberResponseView view = getResponseView(this::createMember);
+        MemberResponseView view = memberHttpTest.createMember(TEST_MEMBER);
 
         assertThat(view).isNotNull();
         assertThat(view.getEmail()).isEqualTo(TEST_MEMBER_EMAIL);
@@ -34,7 +35,7 @@ public class MemberAcceptanceTest extends AbstractAcceptanceTest {
     @DisplayName("회원 탈퇴를 할 수 있다")
     @Test
     void beAbleToWithdrawal() {
-        MemberResponseView view = getResponseView(this::createMember);
+        MemberResponseView view = memberHttpTest.createMember(TEST_MEMBER);
 
         webTestClient.delete().uri("/members/" + view.getId())
                 .exchange()
@@ -45,25 +46,25 @@ public class MemberAcceptanceTest extends AbstractAcceptanceTest {
     @DisplayName("로그인을 할 수 있다")
     @Test
     void beAbleToLogin() {
-        createMember();
+        memberHttpTest.createMemberRequest(TEST_MEMBER);
 
-        LoginResponseView view = getResponseView(this::loginMember);
+        String authorization = memberHttpTest.loginMember(TEST_MEMBER);
+        final String[] splits = authorization.split(" ");
 
-        assertThat(view).isNotNull();
-        assertThat(view.getTokenType()).isEqualTo(TOKEN_TYPE);
-        assertThat(view.getAccessToken()).isNotEmpty();
+        assertThat(authorization).isNotEmpty();
+        assertThat(splits).hasSize(2);
+        assertThat(splits[0]).isEqualTo(TOKEN_TYPE);
     }
 
     @DisplayName("회원 자신의 정보를 조회 할 수 있다")
     @Test
     void beAbleToFindMe() {
-        createMember();
+        memberHttpTest.createMemberRequest(TEST_MEMBER);
 
-        LoginResponseView view = getResponseView(this::loginMember);
-        String authorization = view.getTokenType() +" "+ view.getAccessToken();
+        String token = memberHttpTest.loginMember(TEST_MEMBER);
 
         webTestClient.get().uri("/members/me")
-                .header(AUTHORIZATION, authorization)
+                .header(AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -71,43 +72,6 @@ public class MemberAcceptanceTest extends AbstractAcceptanceTest {
                 .jsonPath("$.email").isEqualTo(TEST_MEMBER_EMAIL)
                 .jsonPath("$.name").isEqualTo(TEST_MEMBER_NAME);
 
-    }
-
-    private EntityExchangeResult<MemberResponseView> createMember() {
-        String inputJson = jsonOf(TEST_MEMBER);
-
-        return webTestClient.post().uri("/members")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(inputJson), String.class)
-                .exchange()
-                .expectStatus().isCreated()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectHeader().exists("Location")
-                .expectBody(MemberResponseView.class)
-                .returnResult();
-    }
-
-    private EntityExchangeResult<LoginResponseView> loginMember() {
-        Map<String, Object> map = Map.ofEntries(
-                Map.entry("email", TEST_MEMBER_EMAIL),
-                Map.entry("password", TEST_MEMBER_PASSWORD)
-        );
-
-        String inputJson = jsonOf(map);
-
-        return webTestClient.post().uri("/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(inputJson), String.class)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody(LoginResponseView.class)
-                .returnResult();
-    }
-
-    private <T> T getResponseView(Supplier<EntityExchangeResult<T>> supplier) {
-        EntityExchangeResult<T> result = supplier.get();
-        return result.getResponseBody();
     }
 
 }

--- a/src/test/java/atdd/path/web/MemberAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/MemberAcceptanceTest.java
@@ -37,7 +37,7 @@ public class MemberAcceptanceTest extends AbstractAcceptanceTest {
     void beAbleToWithdrawal() {
         MemberResponseView view = memberHttpTest.createMember(TEST_MEMBER);
 
-        webTestClient.delete().uri("/members/" + view.getId())
+        webTestClient.delete().uri(MEMBER_URL + "/" + view.getId())
                 .exchange()
                 .expectStatus()
                 .isNoContent();
@@ -63,7 +63,7 @@ public class MemberAcceptanceTest extends AbstractAcceptanceTest {
 
         String token = memberHttpTest.loginMember(TEST_MEMBER);
 
-        webTestClient.get().uri("/members/me")
+        webTestClient.get().uri(MEMBER_URL + "/me")
                 .header(HttpHeaders.AUTHORIZATION, token)
                 .exchange()
                 .expectStatus().isOk()

--- a/src/test/java/atdd/path/web/MemberHttpTest.java
+++ b/src/test/java/atdd/path/web/MemberHttpTest.java
@@ -1,5 +1,6 @@
 package atdd.path.web;
 
+import atdd.path.AbstractHttpTest;
 import atdd.path.application.dto.LoginResponseView;
 import atdd.path.application.dto.MemberResponseView;
 import atdd.path.domain.Member;
@@ -10,14 +11,14 @@ import reactor.core.publisher.Mono;
 
 import java.util.Map;
 
+import static atdd.path.TestConstant.LOGIN_URL;
+import static atdd.path.TestConstant.MEMBER_URL;
 import static atdd.path.TestUtils.jsonOf;
 
-public class MemberHttpTest {
-
-    private WebTestClient webTestClient;
+public class MemberHttpTest extends AbstractHttpTest {
 
     public MemberHttpTest(WebTestClient webTestClient) {
-        this.webTestClient = webTestClient;
+        super(webTestClient);
     }
 
     public MemberResponseView createMember(Member member) {
@@ -34,15 +35,7 @@ public class MemberHttpTest {
 
         String inputJson = jsonOf(member);
 
-        return webTestClient.post().uri("/members")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(inputJson), String.class)
-                .exchange()
-                .expectStatus().isCreated()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectHeader().exists("Location")
-                .expectBody(MemberResponseView.class)
-                .returnResult();
+        return createRequest(MemberResponseView.class, MEMBER_URL, inputJson);
     }
 
     public String loginMember(Member member) {
@@ -58,8 +51,7 @@ public class MemberHttpTest {
         );
 
         String inputJson = jsonOf(map);
-
-        return webTestClient.post().uri("/login")
+        return webTestClient.post().uri(LOGIN_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(Mono.just(inputJson), String.class)
                 .exchange()

--- a/src/test/java/atdd/path/web/MemberHttpTest.java
+++ b/src/test/java/atdd/path/web/MemberHttpTest.java
@@ -1,0 +1,72 @@
+package atdd.path.web;
+
+import atdd.path.application.dto.LoginResponseView;
+import atdd.path.application.dto.MemberResponseView;
+import atdd.path.domain.Member;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+import static atdd.path.TestUtils.jsonOf;
+
+public class MemberHttpTest {
+
+    private WebTestClient webTestClient;
+
+    public MemberHttpTest(WebTestClient webTestClient) {
+        this.webTestClient = webTestClient;
+    }
+
+    public MemberResponseView createMember(Member member) {
+        EntityExchangeResult<MemberResponseView> result = createMemberRequest(member);
+        return result.getResponseBody();
+    }
+
+    public EntityExchangeResult<MemberResponseView> createMemberRequest(Member member) {
+        Map<String, Object> map = Map.ofEntries(
+                Map.entry("email", member.getEmail()),
+                Map.entry("name", member.getName()),
+                Map.entry("password", member.getPassword())
+        );
+
+        String inputJson = jsonOf(member);
+
+        return webTestClient.post().uri("/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(inputJson), String.class)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectHeader().exists("Location")
+                .expectBody(MemberResponseView.class)
+                .returnResult();
+    }
+
+    public String loginMember(Member member) {
+        EntityExchangeResult<LoginResponseView> result = loginMemberRequest(member);
+        LoginResponseView view = result.getResponseBody();
+        return view.getTokenType() + " " + view.getAccessToken();
+    }
+
+    public EntityExchangeResult<LoginResponseView> loginMemberRequest(Member member) {
+        Map<String, Object> map = Map.ofEntries(
+                Map.entry("email", member.getEmail()),
+                Map.entry("password", member.getPassword())
+        );
+
+        String inputJson = jsonOf(map);
+
+        return webTestClient.post().uri("/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(inputJson), String.class)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(LoginResponseView.class)
+                .returnResult();
+    }
+
+}

--- a/src/test/java/atdd/path/web/StationAcceptanceTest.java
+++ b/src/test/java/atdd/path/web/StationAcceptanceTest.java
@@ -13,7 +13,6 @@ import static atdd.path.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StationAcceptanceTest extends AbstractAcceptanceTest {
-    public static final String STATION_URL = "/stations";
 
     private LineHttpTest lineHttpTest;
     private StationHttpTest stationHttpTest;

--- a/src/test/java/atdd/path/web/StationHttpTest.java
+++ b/src/test/java/atdd/path/web/StationHttpTest.java
@@ -1,50 +1,32 @@
 package atdd.path.web;
 
+import atdd.path.AbstractHttpTest;
 import atdd.path.application.dto.StationResponseView;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-public class StationHttpTest {
-    public WebTestClient webTestClient;
+import static atdd.path.TestConstant.STATION_URL;
+
+public class StationHttpTest extends AbstractHttpTest {
 
     public StationHttpTest(WebTestClient webTestClient) {
-        this.webTestClient = webTestClient;
+        super(webTestClient);
     }
 
     public EntityExchangeResult<StationResponseView> createStationRequest(String stationName) {
         String inputJson = "{\"name\":\"" + stationName + "\"}";
 
-        return webTestClient.post().uri("/stations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(inputJson), String.class)
-                .exchange()
-                .expectStatus().isCreated()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectHeader().exists("Location")
-                .expectBody(StationResponseView.class)
-                .returnResult();
+        return createRequest(StationResponseView.class, STATION_URL, inputJson);
     }
 
     public EntityExchangeResult<StationResponseView> retrieveStationRequest(String uri) {
-        return webTestClient.get().uri(uri)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody(StationResponseView.class)
-                .returnResult();
+        return findRequest(StationResponseView.class, uri);
     }
 
     public EntityExchangeResult<List<StationResponseView>> showStationsRequest() {
-        return webTestClient.get().uri("/stations")
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBodyList(StationResponseView.class)
-                .returnResult();
+        return findRequestList(StationResponseView.class, STATION_URL);
     }
 
     public Long createStation(String stationName) {
@@ -53,6 +35,6 @@ public class StationHttpTest {
     }
 
     public EntityExchangeResult<StationResponseView> retrieveStation(Long stationId) {
-        return retrieveStationRequest("/stations/" + stationId);
+        return retrieveStationRequest(STATION_URL + "/" + stationId);
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  security:
+    jwt:
+      token:
+        expire-length: 2000


### PR DESCRIPTION
안녕하세요. 리뷰어님
저번 리뷰내용과 이번 주 미션에 대해 
제가 이해한 부분에 한해서 구현하였습니다.

---
### 1. 미션

1. 즐겨찾기 관리
    * 즐겨찾는 지하철역 관리
    * 즐겨찾는 지하철 경로 관리

### 2. 2단계 코드리뷰

1. https://github.com/next-step/atdd-subway-favorite/pull/9#discussion_r380411153
일단 private이로도 동작 가능한지 확인 하였습니다.
JPA에 대해 강의나 공부를 기본 생성자 접근권한은 protected 정도면 
된다고 들어서 DTO 클래스를 만들 때에도 생각 없이 protected 로 했던 같습니다.

2. https://github.com/next-step/atdd-subway-favorite/pull/9#discussion_r380411416
MockHttpServletRequest, MockHttpServletResponse 말씀하셔서 
MockMvc를 통해서 컨트롤러 테스트 하듯이 테스트를 작성 했습니다.
다만 테스트 케이스를 통과 했나, 안했나 정도 밖에서 하지 못했습니다.

3. https://github.com/next-step/atdd-subway-favorite/pull/9#discussion_r380411531
2번 케이스 마찬가지로 단순하게 controller, service, dao 만 테스트 하는데 TDD라고 생각 했습니다.

4. https://github.com/next-step/atdd-subway-favorite/pull/9#discussion_r380411731
일단 제가 아무생각이 가져다 쓴 잘못이 큰데요. 로직상에서 해당 if 문이 없는게 DB 조회를 
한번 하기는 하지만 에러처리가 되기 때문에 if 문이 없어도 되지 않을까 생각했습니다.<p/>
다만 말씀하신 null object 에 대해서는 제가 100% 이해를 하지는 못했지만
장점으로는 걸어두신 링크에 있는 내용대로
**"종종 null 검사의 필요를 제거하고, 코드를 단순화하는 데 도움이 된다"**
나와 있기는 하나 Optional 클래스가 있어서 조금은 대체 할 수 있지 않을까 합니다.<p/>
그리고 적용을 한 번 해본다고 했을 때
Member.java 에는 빈값을 가지는 Member 도메인 객체를 반환하는 static 메소드를 추가하고
말씀하신 부분에서는 해당 메소드를 사용하면 되지 않을까 생각했었습니다...<p/>
``` java 
public static Member emptyMember() {
    return new Member("", "", "");
}
```
```java
if (Strings.isBlank(email)) {
    return Member.emptyMember();
}
```
