### PR TITLE
Step1: 로그인 인증 프로세스 실습, 토근 기반 로그인 기능 

### DIFF
--- a/src/main/java/nextstep/subway/auth/dto/TokenResponse.java
+++ b/src/main/java/nextstep/subway/auth/dto/TokenResponse.java
@@ -3,11 +3,15 @@ package nextstep.subway.auth.dto;
 public class TokenResponse {
     private String accessToken;
 
-    public TokenResponse() {
+    private TokenResponse() {
     }
 
-    public TokenResponse(String accessToken) {
+    private TokenResponse(String accessToken) {
         this.accessToken = accessToken;
+    }
+
+    public static TokenResponse of(String accessToken) {
+        return new TokenResponse(accessToken);
     }
 
     public String getAccessToken() {

--- a/src/main/java/nextstep/subway/auth/exception/InvalidCredentialsException.java
+++ b/src/main/java/nextstep/subway/auth/exception/InvalidCredentialsException.java
@@ -1,0 +1,10 @@
+package nextstep.subway.auth.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+
+    public static String MESSAGE = "인증 정보가 잘못 되었습니다.";
+
+    public InvalidCredentialsException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/nextstep/subway/auth/exception/NotFoundUserException.java
+++ b/src/main/java/nextstep/subway/auth/exception/NotFoundUserException.java
@@ -1,0 +1,10 @@
+package nextstep.subway.auth.exception;
+
+public class NotFoundUserException extends RuntimeException {
+
+    public static String MESSAGE = "존재하지 않는 회원정보입니다.";
+
+    public NotFoundUserException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/nextstep/subway/auth/ui/session/SessionAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/session/SessionAuthenticationInterceptor.java
@@ -18,7 +18,7 @@ public class SessionAuthenticationInterceptor implements HandlerInterceptor {
     public static final String USERNAME_FIELD = "username";
     public static final String PASSWORD_FIELD = "password";
 
-    private CustomUserDetailsService userDetailsService;
+    private final CustomUserDetailsService userDetailsService;
 
     public SessionAuthenticationInterceptor(CustomUserDetailsService userDetailsService) {
         this.userDetailsService = userDetailsService;

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenSecurityContextPersistenceInterceptor.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 
 public class TokenSecurityContextPersistenceInterceptor implements HandlerInterceptor {
-    private JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public TokenSecurityContextPersistenceInterceptor(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -14,7 +14,7 @@ import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_S
 
 @Service
 public class MemberService {
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     public MemberService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
@@ -43,5 +43,9 @@ public class MemberService {
         SecurityContext context = (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
         LoginMember loginMember = (LoginMember) context.getAuthentication().getPrincipal();
         return MemberResponse.of(loginMember);
+    }
+
+    public MemberResponse findMemberOfMine(Object principal) {
+        return null;
     }
 }

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -1,10 +1,16 @@
 package nextstep.subway.member.application;
+import nextstep.subway.auth.infrastructure.SecurityContext;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
 @Service
 public class MemberService {
@@ -31,5 +37,11 @@ public class MemberService {
 
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
+    }
+
+    public MemberResponse findMemberOfMine(HttpServletRequest request) {
+        SecurityContext context = (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
+        LoginMember loginMember = (LoginMember) context.getAuthentication().getPrincipal();
+        return MemberResponse.of(loginMember);
     }
 }

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -44,8 +44,4 @@ public class MemberService {
         LoginMember loginMember = (LoginMember) context.getAuthentication().getPrincipal();
         return MemberResponse.of(loginMember);
     }
-
-    public MemberResponse findMemberOfMine(Object principal) {
-        return null;
-    }
 }

--- a/src/main/java/nextstep/subway/member/dto/MemberResponse.java
+++ b/src/main/java/nextstep/subway/member/dto/MemberResponse.java
@@ -1,4 +1,5 @@
 package nextstep.subway.member.dto;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
 
 public class MemberResponse {
@@ -17,6 +18,10 @@ public class MemberResponse {
 
     public static MemberResponse of(Member member) {
         return new MemberResponse(member.getId(), member.getEmail(), member.getAge());
+    }
+
+    public static MemberResponse of(LoginMember loginMember) {
+        return new MemberResponse(loginMember.getId(), loginMember.getEmail(), loginMember.getAge());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -54,12 +54,19 @@ public class MemberController {
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine() {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(
+        @AuthenticationPrincipal LoginMember loginMember,
+        @RequestBody MemberRequest param
+    ) {
+        memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine() {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(
+        @AuthenticationPrincipal LoginMember loginMember
+    ) {
+        memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,16 +1,21 @@
 package nextstep.subway.member.ui;
 
+import nextstep.subway.auth.infrastructure.SecurityContext;
 import nextstep.subway.member.application.MemberService;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
+
+import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
 @RestController
 public class MemberController {
-    private MemberService memberService;
+    private final MemberService memberService;
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;
@@ -41,8 +46,8 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<MemberResponse> findMemberOfMine(HttpServletRequest request) {
+        return ResponseEntity.ok(memberService.findMemberOfMine(request));
     }
 
     @PutMapping("/members/me")

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,5 +1,6 @@
 package nextstep.subway.member.ui;
 
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.auth.infrastructure.SecurityContext;
 import nextstep.subway.member.application.MemberService;
 import nextstep.subway.member.domain.LoginMember;
@@ -46,8 +47,10 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(HttpServletRequest request) {
-        return ResponseEntity.ok(memberService.findMemberOfMine(request));
+    public ResponseEntity<MemberResponse> findMemberOfMine(
+        @AuthenticationPrincipal LoginMember loginMember
+    ) {
+        return ResponseEntity.ok().body(MemberResponse.of(loginMember));
     }
 
     @PutMapping("/members/me")

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -69,6 +69,30 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("회원 정보를 관리한다.")
     @Test
     void manageMember() {
+
+        // when: 회원 생성을 요청
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+
+        // then: 회원 생성됨
+        회원_생성됨(createResponse);
+
+        // when: 회원 정보 조회 요청
+        ExtractableResponse<Response> viewResponse = 회원_정보_조회_요청(createResponse);
+
+        // then: 회원 정보 조회됨
+        회원_정보_조회됨(viewResponse, EMAIL, AGE);
+
+        // when: 회원 정보 수정 요청
+        ExtractableResponse<Response> updateResponse = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
+
+        // then: 회원 정보 수정됨
+        회원_정보_수정됨(updateResponse);
+
+        // when: 회원 삭제 요청
+        ExtractableResponse<Response> response = 회원_삭제_요청(createResponse);
+
+        // then: 회원 삭제됨
+        회원_삭제됨(response);
     }
 
     @DisplayName("나의 정보를 관리한다.")

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -119,7 +119,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원_정보_수정됨(updateResponse);
 
         // when: 내 회원 삭제 요청
-        ExtractableResponse<Response> deleteResponse = 회원_삭제_요청(createResponse);
+        ExtractableResponse<Response> deleteResponse = 내_회원_삭제_요청(tokenResponse);
 
         // then: 회원 삭제됨
         회원_삭제됨(deleteResponse);

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.member;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -89,14 +90,38 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원_정보_수정됨(updateResponse);
 
         // when: 회원 삭제 요청
-        ExtractableResponse<Response> response = 회원_삭제_요청(createResponse);
+        ExtractableResponse<Response> deleteResponse = 회원_삭제_요청(createResponse);
 
         // then: 회원 삭제됨
-        회원_삭제됨(response);
+        회원_삭제됨(deleteResponse);
     }
 
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {
+        // when: 회원 생성을 요청
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+
+        // then: 회원 생성 됨
+        회원_생성됨(createResponse);
+
+        // when: 내 회원 정보 조회 요청
+        TokenResponse tokenResponse = 로그인_되어_있음(EMAIL, PASSWORD);
+        ExtractableResponse<Response> viewResponse = 내_회원_정보_조회_요청(tokenResponse);
+
+        // then: 회원 정보 조회 됨
+        회원_정보_조회됨(viewResponse, EMAIL, AGE);
+
+        // when: 회원 정보 수정 요청
+        ExtractableResponse<Response> updateResponse = 내_회원_정보_수정_요청(tokenResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
+
+        // then: 회원 정보 수정됨
+        회원_정보_수정됨(updateResponse);
+
+        // when: 내 회원 삭제 요청
+        ExtractableResponse<Response> deleteResponse = 회원_삭제_요청(createResponse);
+
+        // then: 회원 삭제됨
+        회원_삭제됨(deleteResponse);
     }
 }

--- a/src/test/java/nextstep/subway/member/MemberSteps.java
+++ b/src/test/java/nextstep/subway/member/MemberSteps.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.authentication.FormAuthConfig;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MemberSteps {
     public static final String USERNAME_FIELD = "username";
     public static final String PASSWORD_FIELD = "password";
+
+    public static final String MY_PAGE_URI = "/members/me";
 
     public static TokenResponse 로그인_되어_있음(String email, String password) {
         ExtractableResponse<Response> response = 로그인_요청(email, password);
@@ -89,7 +92,7 @@ public class MemberSteps {
                 .given().log().all()
                 .auth().form(email, password, new FormAuthConfig("/login/session", USERNAME_FIELD, PASSWORD_FIELD))
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/members/me")
+                .when().get(MY_PAGE_URI)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value()).extract();
     }
@@ -98,10 +101,34 @@ public class MemberSteps {
         return RestAssured.given().log().all()
                 .auth().oauth2(tokenResponse.getAccessToken())
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/members/me")
+                .when().get(MY_PAGE_URI)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 내_회원_정보_수정_요청(TokenResponse tokenResponse, String email, String password, Integer age) {
+
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+        params.put("age", age + "");
+
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(tokenResponse.getAccessToken())
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .body(params)
+            .when().put(MY_PAGE_URI)
+            .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 내_회원_삭제_요청(TokenResponse tokenResponse) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(tokenResponse.getAccessToken())
+            .when().delete(MY_PAGE_URI)
+            .then().log().all().extract();
     }
 
     public static void 회원_생성됨(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/subway/member/MemberSteps.java
+++ b/src/test/java/nextstep/subway/member/MemberSteps.java
@@ -6,6 +6,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -108,17 +109,11 @@ public class MemberSteps {
     }
 
     public static ExtractableResponse<Response> 내_회원_정보_수정_요청(TokenResponse tokenResponse, String email, String password, Integer age) {
-
-        Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("password", password);
-        params.put("age", age + "");
-
         return RestAssured
             .given().log().all()
             .auth().oauth2(tokenResponse.getAccessToken())
-            .accept(MediaType.APPLICATION_JSON_VALUE)
-            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(new MemberRequest(email, password, age))
             .when().put(MY_PAGE_URI)
             .then().log().all().extract();
     }


### PR DESCRIPTION
## 요구사항
- [x] 실습
  - [x] MemberAcceptanceTest의 인수 테스트를 통합하기
  - [x] AuthAcceptanceTest의 myInfoWithSession 테스트 메서드를 성공 시키기
- [x] AuthAcceptanceTest의 myInfoWithBearerAuth 테스트 메서드를 성공 시키기
  - [x] TokenAuthenticationInterceptor 구현하기
- [x] MemberAcceptanceTest의 manageMyInfo 성공 시키기
  - [x] @AuthenticationPrincipal을 활용하여 로그인 정보 받아오기

## 질문
- Session 기반으로 manageMyInfo을 작업해보려고 했는데, session 정보(Cookie)가 response에 담기질 않네요. session이 필요할 때 마다 form data를 보내줘야 하는걸까요?


리뷰 잘 부탁드립니다! 🙇‍♂️