### PR TITLE
Step2 - 로그인 리팩터링

### DIFF
--- a/src/main/java/nextstep/subway/auth/domain/User.java
+++ b/src/main/java/nextstep/subway/auth/domain/User.java
@@ -1,0 +1,26 @@
+package nextstep.subway.auth.domain;
+
+public class User {
+    private String username;
+    private String password;
+
+    public User() {
+    }
+
+    public User(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public boolean checkPassword(String password) {
+        return this.password.equals(password);
+    }
+}

--- a/src/main/java/nextstep/subway/auth/infrastructure/AuthConfig.java
+++ b/src/main/java/nextstep/subway/auth/infrastructure/AuthConfig.java
@@ -1,5 +1,6 @@
 package nextstep.subway.auth.infrastructure;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.subway.auth.ui.AuthenticationPrincipalArgumentResolver;
 import nextstep.subway.auth.ui.session.SessionAuthenticationInterceptor;
 import nextstep.subway.auth.ui.session.SessionSecurityContextPersistenceInterceptor;
@@ -14,19 +15,21 @@ import java.util.List;
 
 @Configuration
 public class AuthConfig implements WebMvcConfigurer {
-    private CustomUserDetailsService userDetailsService;
-    private JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
 
-    public AuthConfig(CustomUserDetailsService userDetailsService, JwtTokenProvider jwtTokenProvider) {
+    public AuthConfig(CustomUserDetailsService userDetailsService, JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
         this.userDetailsService = userDetailsService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.objectMapper = objectMapper;
     }
 
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new SessionAuthenticationInterceptor(userDetailsService)).addPathPatterns("/login/session");
-        registry.addInterceptor(new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider)).addPathPatterns("/login/token");
+        registry.addInterceptor(new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper)).addPathPatterns("/login/token");
         registry.addInterceptor(new SessionSecurityContextPersistenceInterceptor());
-        registry.addInterceptor(new TokenSecurityContextPersistenceInterceptor(jwtTokenProvider, userDetailsService));
+        registry.addInterceptor(new TokenSecurityContextPersistenceInterceptor(jwtTokenProvider, userDetailsService, objectMapper));
     }
 
     @Override

--- a/src/main/java/nextstep/subway/auth/infrastructure/AuthConfig.java
+++ b/src/main/java/nextstep/subway/auth/infrastructure/AuthConfig.java
@@ -37,7 +37,11 @@ public class AuthConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List argumentResolvers) {
-        argumentResolvers.add(new AuthenticationPrincipalArgumentResolver());
+        argumentResolvers.add(authenticationPrincipalArgumentResolver());
+    }
+
+    private AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver() {
+        return new AuthenticationPrincipalArgumentResolver();
     }
 
     @Bean

--- a/src/main/java/nextstep/subway/auth/infrastructure/UserDetailService.java
+++ b/src/main/java/nextstep/subway/auth/infrastructure/UserDetailService.java
@@ -1,8 +1,8 @@
 package nextstep.subway.auth.infrastructure;
 
-import nextstep.subway.member.domain.LoginMember;
+import nextstep.subway.auth.domain.User;
 
 @FunctionalInterface
 public interface UserDetailService {
-    LoginMember loadUserByUsername(String username);
+    User loadUserByUsername(String username);
 }

--- a/src/main/java/nextstep/subway/auth/infrastructure/UserDetailService.java
+++ b/src/main/java/nextstep/subway/auth/infrastructure/UserDetailService.java
@@ -1,0 +1,8 @@
+package nextstep.subway.auth.infrastructure;
+
+import nextstep.subway.member.domain.LoginMember;
+
+@FunctionalInterface
+public interface UserDetailService {
+    LoginMember loadUserByUsername(String username);
+}

--- a/src/main/java/nextstep/subway/auth/ui/AuthenticationConverter.java
+++ b/src/main/java/nextstep/subway/auth/ui/AuthenticationConverter.java
@@ -1,0 +1,11 @@
+package nextstep.subway.auth.ui;
+
+import nextstep.subway.auth.domain.AuthenticationToken;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@FunctionalInterface
+public interface AuthenticationConverter {
+    AuthenticationToken convert(HttpServletRequest request) throws IOException;
+}

--- a/src/main/java/nextstep/subway/auth/ui/AuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/AuthenticationInterceptor.java
@@ -3,8 +3,8 @@ package nextstep.subway.auth.ui;
 
 import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.domain.AuthenticationToken;
+import nextstep.subway.auth.domain.User;
 import nextstep.subway.auth.infrastructure.UserDetailService;
-import nextstep.subway.member.domain.LoginMember;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -37,18 +37,18 @@ public abstract class AuthenticationInterceptor implements HandlerInterceptor {
 
     public Authentication authenticate(AuthenticationToken token) {
         String principal = token.getPrincipal();
-        LoginMember userDetails = userDetailsService.loadUserByUsername(principal);
-        checkAuthentication(userDetails, token);
+        User user = userDetailsService.loadUserByUsername(principal);
+        checkAuthentication(user, token);
 
-        return new Authentication(userDetails);
+        return new Authentication(user);
     }
 
-    private void checkAuthentication(LoginMember userDetails, AuthenticationToken token) {
-        if (userDetails == null) {
+    private void checkAuthentication(User user, AuthenticationToken token) {
+        if (user == null) {
             throw new RuntimeException();
         }
 
-        if (!userDetails.checkPassword(token.getCredentials())) {
+        if (!user.checkPassword(token.getCredentials())) {
             throw new RuntimeException();
         }
     }

--- a/src/main/java/nextstep/subway/auth/ui/AuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/AuthenticationInterceptor.java
@@ -1,0 +1,57 @@
+package nextstep.subway.auth.ui;
+
+
+import nextstep.subway.auth.domain.Authentication;
+import nextstep.subway.auth.domain.AuthenticationToken;
+import nextstep.subway.auth.infrastructure.UserDetailService;
+import nextstep.subway.member.domain.LoginMember;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public abstract class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final UserDetailService userDetailsService;
+    private final AuthenticationConverter converter;
+
+    protected AuthenticationInterceptor(UserDetailService userDetailService, AuthenticationConverter converter) {
+        this.userDetailsService = userDetailService;
+        this.converter = converter;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        AuthenticationToken token = converter.convert(request);
+        Authentication authentication = authenticate(token);
+
+        if (authentication == null) {
+            throw new RuntimeException();
+        }
+
+        afterAuthentication(request, response, authentication);
+
+        return false;
+    }
+
+    public Authentication authenticate(AuthenticationToken token) {
+        String principal = token.getPrincipal();
+        LoginMember userDetails = userDetailsService.loadUserByUsername(principal);
+        checkAuthentication(userDetails, token);
+
+        return new Authentication(userDetails);
+    }
+
+    private void checkAuthentication(LoginMember userDetails, AuthenticationToken token) {
+        if (userDetails == null) {
+            throw new RuntimeException();
+        }
+
+        if (!userDetails.checkPassword(token.getCredentials())) {
+            throw new RuntimeException();
+        }
+    }
+
+    public abstract void afterAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException;
+}

--- a/src/main/java/nextstep/subway/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/subway/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -33,7 +33,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
             Map<String, String> principal = (Map) authentication.getPrincipal();
 
             Object[] params = Arrays.stream(parameter.getParameterType().getDeclaredFields())
-                    .map(it -> toObject(it.getType(), principal.get(it.getName())))
+                    .map(it -> toObject(it.getType(), String.valueOf(principal.get(it.getName()))))
                     .toArray();
 
             return parameter.getParameterType().getConstructors()[0].newInstance(params);

--- a/src/main/java/nextstep/subway/auth/ui/SecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/SecurityContextPersistenceInterceptor.java
@@ -1,0 +1,25 @@
+package nextstep.subway.auth.ui;
+
+import nextstep.subway.auth.infrastructure.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public abstract class SecurityContextPersistenceInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            return true;
+        }
+        return proceedAfter(request, response, handler);
+    }
+
+    protected abstract boolean proceedAfter(HttpServletRequest request, HttpServletResponse response, Object handler);
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/nextstep/subway/auth/ui/session/FormAuthenticationConverter.java
+++ b/src/main/java/nextstep/subway/auth/ui/session/FormAuthenticationConverter.java
@@ -1,0 +1,21 @@
+package nextstep.subway.auth.ui.session;
+
+import nextstep.subway.auth.domain.AuthenticationToken;
+import nextstep.subway.auth.ui.AuthenticationConverter;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+public class FormAuthenticationConverter implements AuthenticationConverter {
+    public static final String USERNAME_FIELD = "username";
+    public static final String PASSWORD_FIELD = "password";
+
+    @Override
+    public AuthenticationToken convert(HttpServletRequest request) {
+        Map<String, String[]> paramMap = request.getParameterMap();
+        String principal = paramMap.get(USERNAME_FIELD)[0];
+        String credentials = paramMap.get(PASSWORD_FIELD)[0];
+
+        return new AuthenticationToken(principal, credentials);
+    }
+}

--- a/src/main/java/nextstep/subway/auth/ui/session/SessionAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/session/SessionAuthenticationInterceptor.java
@@ -1,67 +1,28 @@
 package nextstep.subway.auth.ui.session;
 
 import nextstep.subway.auth.domain.Authentication;
-import nextstep.subway.auth.domain.AuthenticationToken;
 import nextstep.subway.auth.infrastructure.SecurityContext;
-import nextstep.subway.member.application.CustomUserDetailsService;
-import nextstep.subway.member.domain.LoginMember;
-import org.springframework.web.servlet.HandlerInterceptor;
+import nextstep.subway.auth.infrastructure.UserDetailService;
+import nextstep.subway.auth.ui.AuthenticationConverter;
+import nextstep.subway.auth.ui.AuthenticationInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import java.util.Map;
+import java.io.IOException;
 
 import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
-public class SessionAuthenticationInterceptor implements HandlerInterceptor {
-    public static final String USERNAME_FIELD = "username";
-    public static final String PASSWORD_FIELD = "password";
+public class SessionAuthenticationInterceptor extends AuthenticationInterceptor {
 
-    private CustomUserDetailsService userDetailsService;
-
-    public SessionAuthenticationInterceptor(CustomUserDetailsService userDetailsService) {
-        this.userDetailsService = userDetailsService;
+    public SessionAuthenticationInterceptor(UserDetailService userDetailsService, AuthenticationConverter converter) {
+        super(userDetailsService, converter);
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        AuthenticationToken token = convert(request);
-        Authentication authentication = authenticate(token);
-
-        if (authentication == null) {
-            throw new RuntimeException();
-        }
-
+    public void afterAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         HttpSession httpSession = request.getSession();
         httpSession.setAttribute(SPRING_SECURITY_CONTEXT_KEY, new SecurityContext(authentication));
         response.setStatus(HttpServletResponse.SC_OK);
-        return false;
-    }
-
-    public AuthenticationToken convert(HttpServletRequest request) {
-        Map<String, String[]> paramMap = request.getParameterMap();
-        String principal = paramMap.get(USERNAME_FIELD)[0];
-        String credentials = paramMap.get(PASSWORD_FIELD)[0];
-
-        return new AuthenticationToken(principal, credentials);
-    }
-
-    public Authentication authenticate(AuthenticationToken token) {
-        String principal = token.getPrincipal();
-        LoginMember userDetails = userDetailsService.loadUserByUsername(principal);
-        checkAuthentication(userDetails, token);
-
-        return new Authentication(userDetails);
-    }
-
-    private void checkAuthentication(LoginMember userDetails, AuthenticationToken token) {
-        if (userDetails == null) {
-            throw new RuntimeException();
-        }
-
-        if (!userDetails.checkPassword(token.getCredentials())) {
-            throw new RuntimeException();
-        }
     }
 }

--- a/src/main/java/nextstep/subway/auth/ui/session/SessionSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/session/SessionSecurityContextPersistenceInterceptor.java
@@ -2,29 +2,20 @@ package nextstep.subway.auth.ui.session;
 
 import nextstep.subway.auth.infrastructure.SecurityContext;
 import nextstep.subway.auth.infrastructure.SecurityContextHolder;
-import org.springframework.web.servlet.HandlerInterceptor;
+import nextstep.subway.auth.ui.SecurityContextPersistenceInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
-public class SessionSecurityContextPersistenceInterceptor implements HandlerInterceptor {
+public class SessionSecurityContextPersistenceInterceptor extends SecurityContextPersistenceInterceptor {
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        if (SecurityContextHolder.getContext().getAuthentication() != null) {
-            return true;
-        }
-
+    protected boolean proceedAfter(HttpServletRequest request, HttpServletResponse response, Object handler) {
         SecurityContext securityContext = (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
         if (securityContext != null) {
             SecurityContextHolder.setContext(securityContext);
         }
         return true;
-    }
-
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationConverter.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationConverter.java
@@ -1,0 +1,26 @@
+package nextstep.subway.auth.ui.token;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.subway.auth.domain.AuthenticationToken;
+import nextstep.subway.auth.dto.TokenRequest;
+import nextstep.subway.auth.ui.AuthenticationConverter;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class TokenAuthenticationConverter implements AuthenticationConverter {
+    private final ObjectMapper objectMapper;
+
+    public TokenAuthenticationConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public AuthenticationToken convert(HttpServletRequest request) throws IOException {
+        TokenRequest tokenRequest = objectMapper.readValue(request.getInputStream(), TokenRequest.class);
+        String principal = tokenRequest.getEmail();
+        String credentials = tokenRequest.getPassword();
+
+        return new AuthenticationToken(principal, credentials);
+    }
+}

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
@@ -19,11 +19,12 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
 
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
-    public TokenAuthenticationInterceptor(CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider) {
+    public TokenAuthenticationInterceptor(CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
         this.customUserDetailsService = customUserDetailsService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.objectMapper = objectMapper;
     }
 
     @Override

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
@@ -2,37 +2,30 @@ package nextstep.subway.auth.ui.token;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.subway.auth.domain.Authentication;
-import nextstep.subway.auth.domain.AuthenticationToken;
-import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.auth.infrastructure.JwtTokenProvider;
-import nextstep.subway.member.application.CustomUserDetailsService;
-import nextstep.subway.member.domain.LoginMember;
+import nextstep.subway.auth.infrastructure.UserDetailService;
+import nextstep.subway.auth.ui.AuthenticationConverter;
+import nextstep.subway.auth.ui.AuthenticationInterceptor;
 import org.springframework.http.MediaType;
-import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public class TokenAuthenticationInterceptor implements HandlerInterceptor {
+public class TokenAuthenticationInterceptor extends AuthenticationInterceptor {
 
-    private final CustomUserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
 
-    public TokenAuthenticationInterceptor(CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
-        this.customUserDetailsService = customUserDetailsService;
+    public TokenAuthenticationInterceptor(UserDetailService customUserDetailsService, JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper, AuthenticationConverter converter) {
+        super(customUserDetailsService, converter);
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
-        AuthenticationToken authenticationToken = convert(request);
-        Authentication authentication = authenticate(authenticationToken);
-
-        // TODO: authentication으로 TokenResponse 추출하기
+    public void afterAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         String payload = objectMapper.writeValueAsString(authentication.getPrincipal());
         String token = jwtTokenProvider.createToken(payload);
         TokenResponse tokenResponse = new TokenResponse(token);
@@ -41,35 +34,5 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getOutputStream().print(responseToClient);
-
-        return false;
-    }
-
-    public AuthenticationToken convert(HttpServletRequest request) throws IOException {
-        // TODO: request에서 AuthenticationToken 객체 생성하기
-        TokenRequest tokenRequest = objectMapper.readValue(request.getInputStream(), TokenRequest.class);
-        String principal = tokenRequest.getEmail();
-        String credentials = tokenRequest.getPassword();
-
-        return new AuthenticationToken(principal, credentials);
-    }
-
-    public Authentication authenticate(AuthenticationToken authenticationToken) {
-        // TODO: AuthenticationToken에서 AuthenticationToken 객체 생성하기
-        String principal = authenticationToken.getPrincipal();
-        LoginMember userDetails = customUserDetailsService.loadUserByUsername(principal);
-        checkAuthentication(userDetails, authenticationToken);
-
-        return new Authentication(userDetails);
-    }
-
-    private void checkAuthentication(LoginMember userDetails, AuthenticationToken authenticationToken) {
-        if (userDetails == null) {
-            throw new RuntimeException();
-        }
-
-        if (!userDetails.checkPassword(authenticationToken.getCredentials())) {
-            throw new RuntimeException();
-        }
     }
 }

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenSecurityContextPersistenceInterceptor.java
@@ -2,12 +2,11 @@ package nextstep.subway.auth.ui.token;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.subway.auth.domain.User;
 import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.infrastructure.*;
 import nextstep.subway.auth.ui.SecurityContextPersistenceInterceptor;
 import nextstep.subway.exceptions.UnMatchedPasswordException;
-import nextstep.subway.member.domain.LoginMember;
-import nextstep.subway.member.domain.Member;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,10 +40,10 @@ public class TokenSecurityContextPersistenceInterceptor extends SecurityContextP
     }
 
     private void checkSecurityContextValidation(SecurityContext securityContext) {
-        Member member = objectMapper.convertValue(securityContext.getAuthentication().getPrincipal(), Member.class);
-        LoginMember loginMember = customUserDetailsService.loadUserByUsername(member.getEmail());
+        User user = objectMapper.convertValue(securityContext.getAuthentication().getPrincipal(), User.class);
+        User foundMember = customUserDetailsService.loadUserByUsername(user.getUsername());
 
-        if (!loginMember.checkPassword(member.getPassword())) {
+        if (!foundMember.checkPassword(user.getPassword())) {
             throw new UnMatchedPasswordException();
         }
 
@@ -53,7 +52,7 @@ public class TokenSecurityContextPersistenceInterceptor extends SecurityContextP
     private SecurityContext extractSecurityContext(String credentials) {
         try {
             String payload = jwtTokenProvider.getPayload(credentials);
-            TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {
+            TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
             };
 
             Map principal = objectMapper.readValue(payload, typeRef);

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenSecurityContextPersistenceInterceptor.java
@@ -17,11 +17,12 @@ import java.util.Map;
 public class TokenSecurityContextPersistenceInterceptor implements HandlerInterceptor {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
-    public TokenSecurityContextPersistenceInterceptor(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService customUserDetailsService) {
+    public TokenSecurityContextPersistenceInterceptor(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService customUserDetailsService, ObjectMapper objectMapper) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.customUserDetailsService = customUserDetailsService;
+        this.objectMapper = objectMapper;
     }
 
     @Override

--- a/src/main/java/nextstep/subway/member/application/CustomUserDetailsService.java
+++ b/src/main/java/nextstep/subway/member/application/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package nextstep.subway.member.application;
 
+import nextstep.subway.auth.infrastructure.UserDetailService;
 import nextstep.subway.exceptions.NotFoundUserException;
 import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
@@ -7,13 +8,14 @@ import nextstep.subway.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CustomUserDetailsService {
+public class CustomUserDetailsService implements UserDetailService {
     private MemberRepository memberRepository;
 
     public CustomUserDetailsService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 
+    @Override
     public LoginMember loadUserByUsername(String email) {
         Member member = memberRepository.findByEmail(email).orElseThrow(NotFoundUserException::new);
         return LoginMember.of(member);

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -26,7 +26,6 @@ public class MemberService {
         return MemberResponse.of(member);
     }
 
-    @Modifying
     public void updateMember(Long id, MemberRequest param) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         member.update(param.toMember());

--- a/src/main/java/nextstep/subway/member/domain/LoginMember.java
+++ b/src/main/java/nextstep/subway/member/domain/LoginMember.java
@@ -1,7 +1,9 @@
 package nextstep.subway.member.domain;
 
 
-public class LoginMember {
+import nextstep.subway.auth.domain.User;
+
+public class LoginMember extends User {
     private Long id;
     private String email;
     private String password;
@@ -15,6 +17,8 @@ public class LoginMember {
     }
 
     public LoginMember(Long id, String email, String password, Integer age) {
+        super(email, password);
+
         this.id = id;
         this.email = email;
         this.password = password;

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,7 +1,6 @@
 package nextstep.subway.member.ui;
 
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
-import nextstep.subway.auth.infrastructure.SecurityContextHolder;
 import nextstep.subway.exceptions.NotFoundUserException;
 import nextstep.subway.exceptions.UnMatchedPasswordException;
 import nextstep.subway.member.application.MemberService;
@@ -47,22 +46,22 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
-        MemberResponse memberResponse = MemberResponse.of(loginMember);
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember member) {
+        MemberResponse memberResponse = MemberResponse.of(member);
 
         return ResponseEntity.ok().body(memberResponse);
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember,
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember member,
                                                              @RequestBody MemberRequest request) {
-        memberService.updateMember(loginMember.getId(), request);
+        memberService.updateMember(member.getId(), request);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
-        memberService.deleteMember(loginMember.getId());
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember member) {
+        memberService.deleteMember(member.getId());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -10,6 +10,7 @@ import nextstep.subway.auth.ui.token.TokenAuthenticationInterceptor;
 import nextstep.subway.member.application.CustomUserDetailsService;
 import nextstep.subway.member.domain.LoginMember;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -27,12 +28,14 @@ class TokenAuthenticationInterceptorTest {
     private static final String PASSWORD = "password";
     public static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno";
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Test
     void convert() throws IOException {
         // given
         CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper);
         MockHttpServletRequest request = createMockRequest();
 
         // when
@@ -47,7 +50,7 @@ class TokenAuthenticationInterceptorTest {
     void authenticate() {
         CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper);
 
         when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
 
@@ -61,7 +64,7 @@ class TokenAuthenticationInterceptorTest {
     void preHandle() throws IOException {
         CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper);
 
         when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
         when(jwtTokenProvider.createToken(anyString())).thenReturn(JWT_TOKEN);
@@ -72,13 +75,13 @@ class TokenAuthenticationInterceptorTest {
 
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
-        assertThat(response.getContentAsString()).isEqualTo(new ObjectMapper().writeValueAsString(new TokenResponse(JWT_TOKEN)));
+        assertThat(response.getContentAsString()).isEqualTo(objectMapper.writeValueAsString(new TokenResponse(JWT_TOKEN)));
     }
 
     private MockHttpServletRequest createMockRequest() throws IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         TokenRequest tokenRequest = new TokenRequest(EMAIL, PASSWORD);
-        request.setContent(new ObjectMapper().writeValueAsString(tokenRequest).getBytes());
+        request.setContent(objectMapper.writeValueAsString(tokenRequest).getBytes());
         return request;
     }
 

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -6,11 +6,15 @@ import nextstep.subway.auth.domain.AuthenticationToken;
 import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.auth.infrastructure.JwtTokenProvider;
+import nextstep.subway.auth.infrastructure.UserDetailService;
+import nextstep.subway.auth.ui.AuthenticationConverter;
+import nextstep.subway.auth.ui.AuthenticationInterceptor;
+import nextstep.subway.auth.ui.session.FormAuthenticationConverter;
+import nextstep.subway.auth.ui.token.TokenAuthenticationConverter;
 import nextstep.subway.auth.ui.token.TokenAuthenticationInterceptor;
 import nextstep.subway.member.application.CustomUserDetailsService;
 import nextstep.subway.member.domain.LoginMember;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -29,17 +33,20 @@ class TokenAuthenticationInterceptorTest {
     public static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    AuthenticationConverter tokenConverter = new TokenAuthenticationConverter(objectMapper);
+    AuthenticationConverter formConverter = new FormAuthenticationConverter();
+
 
     @Test
     void convert() throws IOException {
         // given
-        CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
+        UserDetailService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper);
+        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper, tokenConverter);
         MockHttpServletRequest request = createMockRequest();
 
         // when
-        AuthenticationToken authenticationToken = interceptor.convert(request);
+        AuthenticationToken authenticationToken = tokenConverter.convert(request);
 
         // then
         assertThat(authenticationToken.getPrincipal()).isEqualTo(EMAIL);
@@ -48,9 +55,9 @@ class TokenAuthenticationInterceptorTest {
 
     @Test
     void authenticate() {
-        CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
+        UserDetailService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper);
+        AuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper, formConverter);
 
         when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
 
@@ -62,9 +69,9 @@ class TokenAuthenticationInterceptorTest {
 
     @Test
     void preHandle() throws IOException {
-        CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
+        UserDetailService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper);
+        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper, tokenConverter);
 
         when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
         when(jwtTokenProvider.createToken(anyString())).thenReturn(JWT_TOKEN);

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -40,8 +40,6 @@ class TokenAuthenticationInterceptorTest {
     @Test
     void convert() throws IOException {
         // given
-        UserDetailService userDetailsService = mock(CustomUserDetailsService.class);
-        JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
         MockHttpServletRequest request = createMockRequest();
 
         // when

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -42,7 +42,6 @@ class TokenAuthenticationInterceptorTest {
         // given
         UserDetailService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper, tokenConverter);
         MockHttpServletRequest request = createMockRequest();
 
         // when
@@ -71,7 +70,7 @@ class TokenAuthenticationInterceptorTest {
     void preHandle() throws IOException {
         UserDetailService userDetailsService = mock(CustomUserDetailsService.class);
         JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper, tokenConverter);
+        AuthenticationInterceptor interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, objectMapper, tokenConverter);
 
         when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
         when(jwtTokenProvider.createToken(anyString())).thenReturn(JWT_TOKEN);


### PR DESCRIPTION
안녕하세요 2단계 미션 PR입니다. 😂

미션 내용중 내 정보 수정/삭제 기능은 1단계에서 구현한 것으로 알고 있어 따로 뭔가를 더 하진 않았습니다.

1,2 단계 구현 인증로직의 리팩터링은 Form, Token방식의 각기 다른 인터셉터를 AuthenticationConverter와 Interceptor 그리고 SecurityContextInterceptor 를 추상화하여 구성영역(AuthConfig)에서 각각 맞는 구현체를 주입하는식으로 하였습니다. 

member, auth패키지가 서로 의존하고있다고하고 그 이유를 UserDetailService때문으로 보았기에 UserDetailService를 추상화 하였습니다. 반환타입을 LoginMember로 하는 부분에서 약간 고민했던부분이 스프링 시큐리티에서는 User 객체를 구현하는 AccountContext를 만들어서 의존관계를 끊고 인증객체를 관리하는편으로 했는데, 미션에서는 SpringSecurity의 로직을 따라가지만 실제 해당 라이브러리는 쓰지않기에 따로 MemberContext를 만들어서 관리하려 했지만, 생각해보니 LoginMember라는 객체의 라이프사이클이 인터셉터와 같이 묶어서 가기때문에 이 자체로 MemberContext의 역할을 하고 만약 다른 엔티티가 인증 대상 객체로 사용된다 하더라도 username, password는 동일할 것으로 보여 굳이 따로 클래스를 만들진 않았습니다. 

그리고 고민했던 부분은 이번에 토큰방식, 세션방식의 각각의 로그인방식에서 사용되는 다른 converter를 인터페이스로만들어 구현체를 각각 구현했는데, 처음에는 LoginType이라는 Enum객체를 만들어 converter기능을 각각(TOKEN, FORM) 변수에 Authentication 이라는 타입의 FunctionalInterface를 필드로 제공해서 해당 converting기능을 제공하려했는데, 2가지 타입에 구성영역에서 오히려 주입 과정이 번거로워지는 거같아 오버하는것 같아 제거했는데, 어떻게 생각하시는지 궁금합니다 😁
