### PR TITLE
Step1 - 토큰 기반 로그인 기능

### DIFF
--- a/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
@@ -3,6 +3,7 @@ package nextstep.subway.auth.ui.token;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.domain.AuthenticationToken;
+import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.auth.infrastructure.JwtTokenProvider;
 import nextstep.subway.member.application.CustomUserDetailsService;
@@ -12,6 +13,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Map;
 
 public class TokenAuthenticationInterceptor implements HandlerInterceptor {
 
@@ -31,6 +34,7 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
         // TODO: authentication으로 TokenResponse 추출하기
         TokenResponse tokenResponse = null;
 
+
         String responseToClient = new ObjectMapper().writeValueAsString(tokenResponse);
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
@@ -40,10 +44,9 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
     }
 
     public AuthenticationToken convert(HttpServletRequest request) throws IOException {
-        // TODO: request에서 AuthenticationToken 객체 생성하기
-        String principal = "";
-        String credentials = "";
-
+        TokenRequest tokenRequest = new ObjectMapper().readValue(request.getInputStream(), TokenRequest.class);
+        String principal = tokenRequest.getEmail();
+        String credentials = tokenRequest.getPassword();
         return new AuthenticationToken(principal, credentials);
     }
 

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,8 +1,6 @@
 package nextstep.subway.member.ui;
 
-import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
-import nextstep.subway.auth.infrastructure.SecurityContextHolder;
 import nextstep.subway.member.application.MemberService;
 import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.dto.MemberRequest;
@@ -45,9 +43,8 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        LoginMember loginMember = (LoginMember) authentication.getPrincipal();
+    public ResponseEntity<MemberResponse> findMemberOfMine(
+            @AuthenticationPrincipal LoginMember loginMember) {
         MemberResponse member = memberService.findMember(loginMember.getId());
         return ResponseEntity.ok().body(member);
     }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,6 +1,8 @@
 package nextstep.subway.member.ui;
 
+import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
+import nextstep.subway.auth.infrastructure.SecurityContextHolder;
 import nextstep.subway.member.application.MemberService;
 import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.dto.MemberRequest;
@@ -43,8 +45,9 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(
-            @AuthenticationPrincipal LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> findMemberOfMine() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        LoginMember loginMember = (LoginMember) authentication.getPrincipal();
         MemberResponse member = memberService.findMember(loginMember.getId());
         return ResponseEntity.ok().body(member);
     }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,6 +1,8 @@
 package nextstep.subway.member.ui;
 
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.member.application.MemberService;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;
@@ -41,8 +43,10 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<MemberResponse> findMemberOfMine(
+            @AuthenticationPrincipal LoginMember loginMember) {
+        MemberResponse member = memberService.findMember(loginMember.getId());
+        return ResponseEntity.ok().body(member);
     }
 
     @PutMapping("/members/me")

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -50,12 +50,16 @@ public class MemberController {
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine() {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        MemberRequest memberRequest
+                = new MemberRequest(loginMember.getEmail(), loginMember.getPassword(), loginMember.getAge());
+        memberService.updateMember(loginMember.getId(), memberRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine() {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -29,6 +29,19 @@ class TokenAuthenticationInterceptorTest {
 
     @Test
     void convert() throws IOException {
+        // given
+        CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
+        JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+        TokenAuthenticationInterceptor tokenAuthenticationInterceptor
+                                        = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+        MockHttpServletRequest request = createMockRequest();
+
+        // when
+        AuthenticationToken convertedToken = tokenAuthenticationInterceptor.convert(request);
+
+        // then
+        assertThat(convertedToken.getPrincipal()).isEqualTo(EMAIL);
+        assertThat(convertedToken.getCredentials()).isEqualTo(PASSWORD);
     }
 
     @Test

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -9,6 +9,7 @@ import nextstep.subway.auth.infrastructure.JwtTokenProvider;
 import nextstep.subway.auth.ui.token.TokenAuthenticationInterceptor;
 import nextstep.subway.member.application.CustomUserDetailsService;
 import nextstep.subway.member.domain.LoginMember;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,17 +28,24 @@ class TokenAuthenticationInterceptorTest {
     private static final String PASSWORD = "password";
     public static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno";
 
+    private TokenAuthenticationInterceptor interceptor;
+    private CustomUserDetailsService userDetailsService;
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        userDetailsService = mock(CustomUserDetailsService.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+    }
+
     @Test
     void convert() throws IOException {
         // given
-        CustomUserDetailsService userDetailsService = mock(CustomUserDetailsService.class);
-        JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenAuthenticationInterceptor tokenAuthenticationInterceptor
-                                        = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
         MockHttpServletRequest request = createMockRequest();
 
         // when
-        AuthenticationToken convertedToken = tokenAuthenticationInterceptor.convert(request);
+        AuthenticationToken convertedToken = interceptor.convert(request);
 
         // then
         assertThat(convertedToken.getPrincipal()).isEqualTo(EMAIL);
@@ -46,10 +54,33 @@ class TokenAuthenticationInterceptorTest {
 
     @Test
     void authenticate() {
+        // given
+        when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
+        AuthenticationToken authenticationToken = new AuthenticationToken(EMAIL, PASSWORD);
+
+        // when
+        Authentication authentication = interceptor.authenticate(authenticationToken);
+
+        // then
+        assertThat(authentication.getPrincipal()).isNotNull();
     }
 
     @Test
     void preHandle() throws IOException {
+        // given
+        when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
+        when(jwtTokenProvider.createToken(anyString())).thenReturn(JWT_TOKEN);
+
+        MockHttpServletRequest request = createMockRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(response.getContentAsString()).isEqualTo(new ObjectMapper().writeValueAsString(new TokenResponse(JWT_TOKEN)));
     }
 
     private MockHttpServletRequest createMockRequest() throws IOException {
@@ -58,5 +89,4 @@ class TokenAuthenticationInterceptorTest {
         request.setContent(new ObjectMapper().writeValueAsString(tokenRequest).getBytes());
         return request;
     }
-
 }

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -1,13 +1,11 @@
 package nextstep.subway.member;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.auth.dto.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 
 import static nextstep.subway.member.MemberSteps.*;
 
@@ -124,25 +122,5 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         회원_삭제됨(deleteResponse);
-    }
-
-    private ExtractableResponse<Response> 내_정보_수정_요청(TokenResponse loginResponse, String newEmail, String newPassword, int newAge) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(loginResponse.getAccessToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .put("/members/me")
-                .then().log().all()
-                .extract();
-    }
-
-    private ExtractableResponse<Response> 내_정보_삭제_요청(TokenResponse loginResponse) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(loginResponse.getAccessToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .delete("/members/me")
-                .then().log().all()
-                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -47,7 +47,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
 
         // when
-        ExtractableResponse<Response> response = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
+        ExtractableResponse<Response> response = 회원_정보_수정_요청(createResponse, NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
 
         // then
         회원_정보_수정됨(response);
@@ -69,6 +69,29 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("회원 정보를 관리한다.")
     @Test
     void manageMember() {
+        // when
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+
+        // then
+        회원_생성됨(createResponse);
+
+        // when
+        ExtractableResponse<Response> searchResponse = 회원_정보_조회_요청(createResponse);
+
+        // then
+        회원_정보_조회됨(searchResponse, EMAIL, AGE);
+
+        // when
+        ExtractableResponse<Response> modifyResponse = 회원_정보_수정_요청(createResponse, NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
+
+        // then
+        회원_정보_수정됨(modifyResponse);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = 회원_삭제_요청(createResponse);
+
+        // then
+        회원_삭제됨(deleteResponse);
     }
 
     @DisplayName("나의 정보를 관리한다.")

--- a/src/test/java/nextstep/subway/member/MemberSteps.java
+++ b/src/test/java/nextstep/subway/member/MemberSteps.java
@@ -104,6 +104,26 @@ public class MemberSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 내_정보_수정_요청(TokenResponse loginResponse, String newEmail, String newPassword, int newAge) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(loginResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 내_정보_삭제_요청(TokenResponse loginResponse) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(loginResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
     public static void 회원_생성됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }


### PR DESCRIPTION
- [ ] MemberAcceptanceTest의 인수 테스트를 통합하기
- [ ] AuthAcceptanceTest의 myInfoWithSession 테스트 메서드를 성공 시키기
- [ ] AuthAcceptanceTest의 myInfoWithBearerAuth 테스트 메서드를 성공 시키기
   - [ ] TokenAuthenticationInterceptor 구현하기
- [ ] MemberAcceptanceTest의 manageMyInfo 성공 시키기
   - [ ] @AuthenticationPrincipal을 활용하여 로그인 정보 받아오기
 
==========================================

안녕하세요 리뷰어님-!
이번 단계는 처음부터 어렵네요 @.@
감이 안와서 영상 다시보고 힌트를 보고
거의 테스트 코드는 복붙하다 시피 하니
그나마 대충 이런 내용이구나 하고 이해가 되어서 진행이 가능했습니다ㅠ

그래도 막상 하고 나니까 세션 방식과 토큰 방식이 어떤 면에서 다른지와
인터셉터랑 파라미터 리졸버가 컨트롤러에 도달하기 전에 어떻게 파라미터들을
가공해서 전달해주는지 알 수 있어서 1단계 진행한 것만으로도 많이 배우게 된 것 같습니다.
저희 회사 사이트도 로그인 정보 관련해서 토큰 방식을 사용하는 것 같은데,
제가 해당 파트 담당이 아니라서 잘 모르는 부분이었습니다. 
그런데 이번 기회로 배울 수 있어서 참 좋네요 ㅎㅎ

주절주절 했는데😅, 이번주차 리뷰 잘 부탁드립니다-!
지적 팍팍 부탁드립니다.
조금 느리더라도 부족한 부분 
많이 배우고 싶어요!