### PR TITLE
1단계 - 토큰 기반 로그인 기능

### DIFF
--- a/src/main/java/nextstep/subway/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/nextstep/subway/auth/infrastructure/JwtTokenProvider.java
@@ -13,8 +13,9 @@ public class JwtTokenProvider {
     @Value("${security.jwt.token.expire-length}")
     private long validityInMilliseconds;
 
+    // header.payload.signature
     public String createToken(String payload) {
-        Claims claims = Jwts.claims().setSubject(payload);
+        Claims claims = Jwts.claims().setSubject(payload); // claims = 권한 = 내용 = payload
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 

--- a/src/main/java/nextstep/subway/auth/ui/session/SessionSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/session/SessionSecurityContextPersistenceInterceptor.java
@@ -23,7 +23,7 @@ public class SessionSecurityContextPersistenceInterceptor implements HandlerInte
         return true;
     }
 
-    @Override
+    @Override // view 랜더링 이후
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
         SecurityContextHolder.clearContext();
     }

--- a/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/token/TokenAuthenticationInterceptor.java
@@ -27,6 +27,7 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        // 요청으로 들어온 인증정보 확인
         AuthenticationToken authenticationToken = convert(request);
         Authentication authentication = authenticate(authenticationToken);
 
@@ -34,6 +35,7 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
             throw new RuntimeException("인증에 실패하였습니다.");
         }
 
+        // TokenResponse를 응답
         String payload = new ObjectMapper().writeValueAsString(authentication.getPrincipal());
         String token = jwtTokenProvider.createToken(payload);
         TokenResponse tokenResponse = new TokenResponse(token);
@@ -57,6 +59,7 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
     }
 
     public Authentication authenticate(AuthenticationToken authenticationToken) {
+        // AuthenticationToken -> Authentication
         LoginMember loginMember = customUserDetailsService.loadUserByUsername(authenticationToken.getPrincipal());
 
         if(loginMember == null){

--- a/src/main/java/nextstep/subway/member/application/CustomUserDetailsService.java
+++ b/src/main/java/nextstep/subway/member/application/CustomUserDetailsService.java
@@ -6,7 +6,8 @@ import nextstep.subway.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CustomUserDetailsService {
+public class
+CustomUserDetailsService {
     private MemberRepository memberRepository;
 
     public CustomUserDetailsService(MemberRepository memberRepository) {

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -1,10 +1,16 @@
 package nextstep.subway.member.application;
+
+import nextstep.subway.auth.infrastructure.SecurityContext;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
 @Service
 public class MemberService {
@@ -31,5 +37,11 @@ public class MemberService {
 
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
+    }
+
+    public MemberResponse findMemberOfMine(HttpServletRequest request) {
+        SecurityContext securityContext = (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
+        LoginMember loginMember = (LoginMember) securityContext.getAuthentication().getPrincipal();
+        return MemberResponse.of(loginMember);
     }
 }

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package nextstep.subway.member.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.xml.bind.v2.TODO;
 import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.infrastructure.SecurityContext;
 import nextstep.subway.member.domain.LoginMember;
@@ -12,6 +13,9 @@ import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.io.IOException;
+
+import static nextstep.subway.auth.infrastructure.AuthorizationExtractor.ACCESS_TOKEN_TYPE;
 import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
 @Service
@@ -35,15 +39,15 @@ public class MemberService {
     public void updateMember(Long id, MemberRequest param) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         member.update(param.toMember());
+        memberRepository.save(member);
     }
 
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
     }
 
-    public MemberResponse findMemberOfMine(HttpServletRequest request) {
-        SecurityContext securityContext = (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
-        LoginMember loginMember = (LoginMember) securityContext.getAuthentication().getPrincipal();
+    public MemberResponse findMemberOfMine(LoginMember loginMember) {
         return MemberResponse.of(loginMember);
     }
+
 }

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -1,5 +1,7 @@
 package nextstep.subway.member.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.infrastructure.SecurityContext;
 import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -1,24 +1,15 @@
 package nextstep.subway.member.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.xml.bind.v2.TODO;
-import nextstep.subway.auth.dto.TokenRequest;
-import nextstep.subway.auth.infrastructure.SecurityContext;
 import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.stereotype.Service;
-
-import javax.servlet.http.HttpServletRequest;
-
-import java.io.IOException;
-
-import static nextstep.subway.auth.infrastructure.AuthorizationExtractor.ACCESS_TOKEN_TYPE;
-import static nextstep.subway.auth.infrastructure.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class MemberService {
     private MemberRepository memberRepository;
 
@@ -31,6 +22,7 @@ public class MemberService {
         return MemberResponse.of(member);
     }
 
+    @Transactional(readOnly = true)
     public MemberResponse findMember(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         return MemberResponse.of(member);
@@ -39,13 +31,14 @@ public class MemberService {
     public void updateMember(Long id, MemberRequest param) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         member.update(param.toMember());
-        memberRepository.save(member);
+        //memberRepository.save(member);
     }
 
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
     }
 
+    @Transactional(readOnly = true)
     public MemberResponse findMemberOfMine(LoginMember loginMember) {
         return MemberResponse.of(loginMember);
     }

--- a/src/main/java/nextstep/subway/member/dto/MemberResponse.java
+++ b/src/main/java/nextstep/subway/member/dto/MemberResponse.java
@@ -1,4 +1,5 @@
 package nextstep.subway.member.dto;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
 
 public class MemberResponse {
@@ -13,6 +14,10 @@ public class MemberResponse {
         this.id = id;
         this.email = email;
         this.age = age;
+    }
+
+    public static MemberResponse of(LoginMember loginMember){
+        return new MemberResponse(loginMember.getId(), loginMember.getEmail(), loginMember.getAge());
     }
 
     public static MemberResponse of(Member member) {

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -49,12 +49,14 @@ public class MemberController {
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine() {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember, @RequestBody MemberRequest param) {
+        memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine() {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,12 +1,13 @@
 package nextstep.subway.member.ui;
 
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.member.application.MemberService;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 
 @RestController
@@ -42,8 +43,8 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(HttpServletRequest request) {
-        MemberResponse response = memberService.findMemberOfMine(request);
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        MemberResponse response = memberService.findMemberOfMine(loginMember);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -6,6 +6,7 @@ import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 
 @RestController
@@ -41,8 +42,9 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<MemberResponse> findMemberOfMine(HttpServletRequest request) {
+        MemberResponse response = memberService.findMemberOfMine(request);
+        return ResponseEntity.ok().body(response);
     }
 
     @PutMapping("/members/me")

--- a/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/auth/TokenAuthenticationInterceptorTest.java
@@ -9,6 +9,8 @@ import nextstep.subway.auth.infrastructure.JwtTokenProvider;
 import nextstep.subway.auth.ui.token.TokenAuthenticationInterceptor;
 import nextstep.subway.member.application.CustomUserDetailsService;
 import nextstep.subway.member.domain.LoginMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,16 +29,61 @@ class TokenAuthenticationInterceptorTest {
     private static final String PASSWORD = "password";
     public static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno";
 
+    private CustomUserDetailsService userDetailsService;
+    private JwtTokenProvider jwtTokenProvider;
+    TokenAuthenticationInterceptor interceptor;
+
+    @BeforeEach
+    void setUp(){
+        // given
+        userDetailsService = mock(CustomUserDetailsService.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        interceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+    }
+
     @Test
+    @DisplayName("요청에서 인증토큰 가져오기 : request -> AuthenticationToken")
     void convert() throws IOException {
+        // given
+        MockHttpServletRequest request = createMockRequest();
+
+        // when
+        AuthenticationToken authenticationToken = interceptor.convert(request);
+
+        // then
+        assertThat(authenticationToken.getPrincipal()).isEqualTo(EMAIL);
+        assertThat(authenticationToken.getCredentials()).isEqualTo(PASSWORD);
     }
 
     @Test
+    @DisplayName("인증하기 : AuthenticationToken -> Authentication")
     void authenticate() {
+        // given
+        when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
+
+        // when
+        AuthenticationToken authenticationToken = new AuthenticationToken(EMAIL, PASSWORD);
+        Authentication authentication = interceptor.authenticate(authenticationToken);
+
+        assertThat(authentication.getPrincipal()).isNotNull();
     }
 
     @Test
+    @DisplayName("인증성공후 -> TokenResponse를 응답")
     void preHandle() throws IOException {
+        // given
+        when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(new LoginMember(1L, EMAIL, PASSWORD, 20));
+        when(jwtTokenProvider.createToken(anyString())).thenReturn(JWT_TOKEN);
+
+        // when
+        MockHttpServletRequest request = createMockRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(response.getContentAsString()).isEqualTo(new ObjectMapper().writeValueAsString(new TokenResponse(JWT_TOKEN)));
     }
 
     private MockHttpServletRequest createMockRequest() throws IOException {

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -93,5 +93,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {
+
     }
 }

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -69,6 +69,25 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("회원 정보를 관리한다.")
     @Test
     void manageMember() {
+        //when 회원 생성을 요청
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        //then 회원 생성됨
+        회원_생성됨(createResponse);
+
+        //when 회원 정보 조회 요청
+        ExtractableResponse<Response> response = 회원_정보_조회_요청(createResponse);
+        //then 회원 정보 조회됨
+        회원_정보_조회됨(response, EMAIL, AGE);
+
+        //when 회원 정보 수정 요청
+        response = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
+        //then 회원 정보 수정됨
+        회원_정보_수정됨(response);
+
+        //when 회원 삭제 요청
+        response = 회원_삭제_요청(createResponse);
+        //then 회원 삭제됨
+        회원_삭제됨(response);
     }
 
     @DisplayName("나의 정보를 관리한다.")

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -1,12 +1,21 @@
 package nextstep.subway.member;
 
+import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.member.domain.MemberRepository;
+import nextstep.subway.member.dto.MemberRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static nextstep.subway.member.MemberSteps.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "email@email.com";
@@ -80,9 +89,10 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원_정보_조회됨(response, EMAIL, AGE);
 
         //when 회원 정보 수정 요청
-        response = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
+        response = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE + 1);
         //then 회원 정보 수정됨
         회원_정보_수정됨(response);
+        수정된_회원_정보_확인(createResponse, NEW_EMAIL, NEW_AGE);
 
         //when 회원 삭제 요청
         response = 회원_삭제_요청(createResponse);
@@ -94,5 +104,33 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void manageMyInfo() {
 
+        // given
+        // |-- when 회원 생성을 요청
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        // |-- then 회원 생성됨
+        회원_생성됨(createResponse);
+
+        // |-- 로그인 요청 + 로그인되어 있음
+        TokenResponse tokenResponse = 로그인_되어_있음(EMAIL, PASSWORD);
+
+        // when 내 정보 조회 요청
+        ExtractableResponse<Response> response = 내_회원_정보_조회_요청(tokenResponse);
+
+        // then 내 정보 조회됨
+        회원_정보_조회됨(response, EMAIL, AGE);
+
+        // when 내 정보 수정 요청
+        response = 내_정보_수정_요청(tokenResponse, new MemberRequest(NEW_EMAIL, NEW_PASSWORD, NEW_AGE));
+
+        // then 내 정보 수정됨
+        회원_정보_수정됨(response);
+        수정된_회원_정보_확인(createResponse, NEW_EMAIL, NEW_AGE);
+
+        // when 내 정보 삭제 요청
+        response = 내_정보_삭제_요청(tokenResponse);
+
+        // then 내 정보 삭제
+        회원_삭제됨(response);
     }
+
 }

--- a/src/test/java/nextstep/subway/member/MemberSteps.java
+++ b/src/test/java/nextstep/subway/member/MemberSteps.java
@@ -132,7 +132,7 @@ public class MemberSteps {
     public static ExtractableResponse<Response> 내_정보_수정_요청(TokenResponse tokenResponse, MemberRequest memberRequest) {
         return RestAssured.given().log().all()
                 .auth().oauth2(tokenResponse.getAccessToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(memberRequest)
                 .when()
                 .put("/members/me")
@@ -143,7 +143,6 @@ public class MemberSteps {
     public static ExtractableResponse<Response> 내_정보_삭제_요청(TokenResponse tokenResponse) {
         return RestAssured.given().log().all()
                 .auth().oauth2(tokenResponse.getAccessToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .delete("/members/me")
                 .then().log().all()

--- a/src/test/java/nextstep/subway/member/MemberSteps.java
+++ b/src/test/java/nextstep/subway/member/MemberSteps.java
@@ -5,6 +5,7 @@ import io.restassured.authentication.FormAuthConfig;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -122,4 +123,31 @@ public class MemberSteps {
     public static void 회원_삭제됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    public static void 수정된_회원_정보_확인(ExtractableResponse<Response> createResponse, String NEW_EMAIL, int NEW_AGE) {
+        ExtractableResponse<Response> response = 회원_정보_조회_요청(createResponse);
+        회원_정보_조회됨(response, NEW_EMAIL, NEW_AGE);
+    }
+
+    public static ExtractableResponse<Response> 내_정보_수정_요청(TokenResponse tokenResponse, MemberRequest memberRequest) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .body(memberRequest)
+                .when()
+                .put("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 내_정보_삭제_요청(TokenResponse tokenResponse) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
 }


### PR DESCRIPTION
안녕하세요 :) 3주차 pr요청 드립니다. 
잘부탁드립니다~!

### 요구사항
로그인 인증 프로세스 실습
- [ ] MemberAcceptanceTest의 인수 테스트를 통합하기
- [ ] AuthAcceptanceTest의 myInfoWithSession 테스트 메서드를 성공 시키기

토큰 기반 로그인 기능
- [ ] AuthAcceptanceTest의 myInfoWithBearerAuth 테스트 메서드를 성공 시키기
    - [ ] TokenAuthenticationInterceptor 구현하기
- [ ] MemberAcceptanceTest의 manageMyInfo 성공 시키기
    - [ ] @AuthenticationPrincipal을 활용하여 로그인 정보 받아오기

### 질문사항
MemberService에서 @Transactional 어노테이션이 없을 경우 save()를 별도로 해주어야 update문이 날라가며, 테스트 코드가 성공하는 것으로 확인 하였습니다.
그런데, JPA에서...Entity의 필드를 다음과 같이 업데이트 할경우, 영속성 컨텍스트에서 조회를 해오기 때문에 update문이 날라가지 않아도 된다고 생각했는데요.. ;-; 그렇지 않은거 같아서요.. 혹시 해당 내용에 대한 설명을 들을 수 있을까요?

`public void updateMember(Long id, MemberRequest param) {
        Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
        member.update(param.toMember());
        //memberRepository.save(member);
    }`