### PR TITLE
3단계 - 즐겨찾기 기능 구현

### DIFF
--- a/src/main/java/nextstep/subway/auth/dto/TokenResponse.java
+++ b/src/main/java/nextstep/subway/auth/dto/TokenResponse.java
@@ -3,7 +3,7 @@ package nextstep.subway.auth.dto;
 public class TokenResponse {
     private String accessToken;
 
-    public TokenResponse() {
+    private TokenResponse() {
     }
 
     public TokenResponse(String accessToken) {

--- a/src/main/java/nextstep/subway/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/subway/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -3,6 +3,7 @@ package nextstep.subway.auth.ui;
 import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.auth.infrastructure.SecurityContextHolder;
+import nextstep.subway.exception.UnauthorizedException;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -13,6 +14,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
@@ -21,6 +23,9 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null){
+            throw new UnauthorizedException();
+        }
         if (authentication.getPrincipal() instanceof Map) {
             return extractPrincipal(parameter, authentication);
         }

--- a/src/main/java/nextstep/subway/auth/ui/authentication/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/subway/auth/ui/authentication/TokenAuthenticationInterceptor.java
@@ -16,8 +16,6 @@ import java.io.IOException;
 
 public class TokenAuthenticationInterceptor extends AuthenticationInterceptor{
 
-    AuthenticationConverter authenticationConverter;
-    CustomUserDetailsService userDetailsService;
     JwtTokenProvider jwtTokenProvider;
 
     public TokenAuthenticationInterceptor(AuthenticationConverter authenticationConverter, UserDetailService userDetailService, JwtTokenProvider jwtTokenProvider) {

--- a/src/main/java/nextstep/subway/exception/NotExistsFavoriteException.java
+++ b/src/main/java/nextstep/subway/exception/NotExistsFavoriteException.java
@@ -1,0 +1,23 @@
+package nextstep.subway.exception;
+
+public class NotExistsFavoriteException extends RuntimeException{
+    public NotExistsFavoriteException() {
+        super();
+    }
+
+    public NotExistsFavoriteException(String message) {
+        super(message);
+    }
+
+    public NotExistsFavoriteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotExistsFavoriteException(Throwable cause) {
+        super(cause);
+    }
+
+    protected NotExistsFavoriteException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/nextstep/subway/exception/NotExistsStationException.java
+++ b/src/main/java/nextstep/subway/exception/NotExistsStationException.java
@@ -1,0 +1,23 @@
+package nextstep.subway.exception;
+
+public class NotExistsStationException extends RuntimeException{
+    public NotExistsStationException() {
+        super();
+    }
+
+    public NotExistsStationException(String message) {
+        super(message);
+    }
+
+    public NotExistsStationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotExistsStationException(Throwable cause) {
+        super(cause);
+    }
+
+    protected NotExistsStationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/nextstep/subway/exception/UnauthorizedException.java
+++ b/src/main/java/nextstep/subway/exception/UnauthorizedException.java
@@ -1,0 +1,27 @@
+package nextstep.subway.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED, reason = "Unauthorized")
+public class UnauthorizedException extends RuntimeException{
+    public UnauthorizedException() {
+        super();
+    }
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+    public UnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnauthorizedException(Throwable cause) {
+        super(cause);
+    }
+
+    protected UnauthorizedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,0 +1,54 @@
+package nextstep.subway.favorite.application;
+
+import com.google.common.collect.Lists;
+import nextstep.subway.favorite.domain.Favorite;
+import nextstep.subway.favorite.domain.FavoriteRepository;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.LoginMember;
+import nextstep.subway.station.application.StationService;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.dto.StationResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+public class FavoriteService {
+
+    private FavoriteRepository favoriteRepository;
+    private StationService stationService;
+
+    public FavoriteService(FavoriteRepository favoriteRepository, StationService stationService) {
+        this.favoriteRepository = favoriteRepository;
+        this.stationService = stationService;
+    }
+
+    public FavoriteResponse createFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
+        Station source = stationService.findById(favoriteRequest.getSourceId());
+        Station target = stationService.findById(favoriteRequest.getTargetId());
+        Favorite favorite = favoriteRepository.save(new Favorite(source.getId(), target.getId()));
+
+        // TODO 로그인한 계정에 즐겨찾기 등록
+
+        return new FavoriteResponse(favorite.getId(), StationResponse.of(source), StationResponse.of(target));
+    }
+
+    @Transactional(readOnly = true)
+    public List<FavoriteResponse> findFavorites(LoginMember loginMember) {
+
+        // TODO 로그인한 계정에 해당하는 즐겨찾기 목록 가져오기
+
+        return (List<FavoriteResponse>) Lists.newArrayList(
+                new FavoriteResponse(1L, new StationResponse(), new StationResponse())
+        );
+    }
+
+    public void deleteFavorite(LoginMember loginMember, Long favoriteId) {
+        // TODO 로그인한 계정에 즐겨찾기 삭제
+        Favorite favorite = favoriteRepository.getOne(favoriteId);
+        favoriteRepository.delete(favorite);
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,6 +1,5 @@
 package nextstep.subway.favorite.application;
 
-import com.google.common.collect.Lists;
 import nextstep.subway.favorite.domain.Favorite;
 import nextstep.subway.favorite.domain.FavoriteRepository;
 import nextstep.subway.favorite.dto.FavoriteRequest;
@@ -28,8 +27,8 @@ public class FavoriteService {
     }
 
     public FavoriteResponse createFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
-        Station source = stationService.findById(favoriteRequest.getSourceId());
-        Station target = stationService.findById(favoriteRequest.getTargetId());
+        Station source = stationService.findById(favoriteRequest.getSource());
+        Station target = stationService.findById(favoriteRequest.getTarget());
         Favorite favorite = favoriteRepository.save(new Favorite(loginMember.getId(), source.getId(), target.getId()));
         return new FavoriteResponse(favorite.getId(), StationResponse.of(source), StationResponse.of(target));
     }
@@ -58,12 +57,12 @@ public class FavoriteService {
     public void checkFavoritesOfMine(List<Favorite> favorites, Long myId) {
         favorites.stream()
                 .forEach(favorite -> {
-                    checkFavoriteOfMine(favorite.getId(), myId);
+                    checkFavoriteOfMine(favorite.getMemberId(), myId);
                 });
     }
 
     public void checkFavoriteOfMine(Long memberId, Long myId) {
-        if(memberId != myId){
+        if(!memberId.equals(myId)){
             throw new IllegalArgumentException();
         }
     }

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -29,10 +29,7 @@ public class FavoriteService {
     public FavoriteResponse createFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
         Station source = stationService.findById(favoriteRequest.getSourceId());
         Station target = stationService.findById(favoriteRequest.getTargetId());
-        Favorite favorite = favoriteRepository.save(new Favorite(source.getId(), target.getId()));
-
-        // TODO 로그인한 계정에 즐겨찾기 등록
-
+        Favorite favorite = favoriteRepository.save(new Favorite(loginMember.getId(), source.getId(), target.getId()));
         return new FavoriteResponse(favorite.getId(), StationResponse.of(source), StationResponse.of(target));
     }
 
@@ -40,15 +37,18 @@ public class FavoriteService {
     public List<FavoriteResponse> findFavorites(LoginMember loginMember) {
 
         // TODO 로그인한 계정에 해당하는 즐겨찾기 목록 가져오기
-
+        // TODO 찾아온 목록이 로그인 계정의 즐찾인지 벨리데이션 - checkFavoriteOfMine
         return (List<FavoriteResponse>) Lists.newArrayList(
                 new FavoriteResponse(1L, new StationResponse(), new StationResponse())
         );
     }
 
     public void deleteFavorite(LoginMember loginMember, Long favoriteId) {
-        // TODO 로그인한 계정에 즐겨찾기 삭제
         Favorite favorite = favoriteRepository.getOne(favoriteId);
+        // TODO 로그인한 계정의 즐찾인지 벨리데이션 추가 - checkFavoriteOfMine
         favoriteRepository.delete(favorite);
+    }
+
+    public void checkFavoriteOfMine(long l, long l1) {
     }
 }

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -14,19 +14,25 @@ public class Favorite extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private Long memberId;
     private Long sourceId;
     private Long targetId;
 
     public Favorite() {
     }
 
-    public Favorite(Long sourceId, Long targetId) {
+    public Favorite(Long memberId, Long sourceId, Long targetId) {
+        this.memberId = memberId;
         this.sourceId = sourceId;
         this.targetId = targetId;
     }
 
     public Long getId() {
         return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
     }
 
     public Long getSourceId() {
@@ -42,11 +48,11 @@ public class Favorite extends BaseEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Favorite favorite = (Favorite) o;
-        return Objects.equals(id, favorite.id) && Objects.equals(sourceId, favorite.sourceId) && Objects.equals(targetId, favorite.targetId);
+        return Objects.equals(id, favorite.id) && Objects.equals(memberId, favorite.memberId) && Objects.equals(sourceId, favorite.sourceId) && Objects.equals(targetId, favorite.targetId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, sourceId, targetId);
+        return Objects.hash(id, memberId, sourceId, targetId);
     }
 }

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -1,0 +1,52 @@
+package nextstep.subway.favorite.domain;
+
+import nextstep.subway.common.BaseEntity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.util.Objects;
+
+@Entity
+public class Favorite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long sourceId;
+    private Long targetId;
+
+    public Favorite() {
+    }
+
+    public Favorite(Long sourceId, Long targetId) {
+        this.sourceId = sourceId;
+        this.targetId = targetId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getSourceId() {
+        return sourceId;
+    }
+
+    public Long getTargetId() {
+        return targetId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Favorite favorite = (Favorite) o;
+        return Objects.equals(id, favorite.id) && Objects.equals(sourceId, favorite.sourceId) && Objects.equals(targetId, favorite.targetId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, sourceId, targetId);
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,0 +1,6 @@
+package nextstep.subway.favorite.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -2,5 +2,9 @@ package nextstep.subway.favorite.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    List<Favorite> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -3,8 +3,19 @@ package nextstep.subway.favorite.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
+
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     List<Favorite> findAllByMemberId(Long memberId);
+
+    Optional<Favorite> findByMemberIdAndId(Long memberId, Long id);
+
+    List<Favorite> findAllBySourceId(Long sourceId);
+    List<Favorite> findAllByTargetId(Long targetId);
+
+    @Override
+    void deleteAll(Iterable<? extends Favorite> entities);
+
 }

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
@@ -1,0 +1,30 @@
+package nextstep.subway.favorite.dto;
+
+public class FavoriteRequest {
+    private Long sourceId;
+    private Long targetId;
+
+    public FavoriteRequest() {
+    }
+
+    public FavoriteRequest(Long sourceId, Long targetId) {
+        this.sourceId = sourceId;
+        this.targetId = targetId;
+    }
+
+    public Long getSourceId() {
+        return sourceId;
+    }
+
+    public void setSourceId(Long sourceId) {
+        this.sourceId = sourceId;
+    }
+
+    public Long getTargetId() {
+        return targetId;
+    }
+
+    public void setTargetId(Long targetId) {
+        this.targetId = targetId;
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
@@ -1,30 +1,30 @@
 package nextstep.subway.favorite.dto;
 
 public class FavoriteRequest {
-    private Long sourceId;
-    private Long targetId;
+    private Long source;
+    private Long target;
 
     public FavoriteRequest() {
     }
 
-    public FavoriteRequest(Long sourceId, Long targetId) {
-        this.sourceId = sourceId;
-        this.targetId = targetId;
+    public FavoriteRequest(Long source, Long target) {
+        this.source = source;
+        this.target = target;
     }
 
-    public Long getSourceId() {
-        return sourceId;
+    public Long getSource() {
+        return source;
     }
 
-    public void setSourceId(Long sourceId) {
-        this.sourceId = sourceId;
+    public void setSource(Long source) {
+        this.source = source;
     }
 
-    public Long getTargetId() {
-        return targetId;
+    public Long getTarget() {
+        return target;
     }
 
-    public void setTargetId(Long targetId) {
-        this.targetId = targetId;
+    public void setTarget(Long target) {
+        this.target = target;
     }
 }

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -1,0 +1,42 @@
+package nextstep.subway.favorite.dto;
+
+import nextstep.subway.station.dto.StationResponse;
+
+public class FavoriteResponse {
+    private Long id;
+    private StationResponse source;
+    private StationResponse target;
+
+    public FavoriteResponse() {
+    }
+
+    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+        this.id = id;
+        this.source = source;
+        this.target = target;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public StationResponse getSource() {
+        return source;
+    }
+
+    public void setSource(StationResponse source) {
+        this.source = source;
+    }
+
+    public StationResponse getTarget() {
+        return target;
+    }
+
+    public void setTarget(StationResponse target) {
+        this.target = target;
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -35,7 +35,7 @@ public class FavoriteController {
 
     @DeleteMapping("/{favoriteId}")
     public ResponseEntity deleteFavorite(@AuthenticationPrincipal LoginMember loginMember, @PathVariable Long favoriteId){
-        favoriteService.deleteFavorite(loginMember, favoriteId);
+        favoriteService.deleteFavoriteOfMine(loginMember, favoriteId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,0 +1,41 @@
+package nextstep.subway.favorite.ui;
+
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
+import nextstep.subway.favorite.application.FavoriteService;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.LoginMember;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/favorites")
+public class FavoriteController {
+
+    private FavoriteService favoriteService;
+
+    public FavoriteController(FavoriteService favoriteService) {
+        this.favoriteService = favoriteService;
+    }
+
+    @PostMapping
+    public ResponseEntity createFavorite(@AuthenticationPrincipal LoginMember loginMember, @RequestBody FavoriteRequest favoriteRequest){
+        FavoriteResponse favorite = favoriteService.createFavorite(loginMember, favoriteRequest);
+        return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).build();
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<FavoriteResponse>> findFavorites(@AuthenticationPrincipal LoginMember loginMember){
+        List<FavoriteResponse> favorites = favoriteService.findFavorites(loginMember);
+        return ResponseEntity.ok().body(favorites);
+    }
+
+    @DeleteMapping("/{favoriteId}")
+    public ResponseEntity deleteFavorite(@AuthenticationPrincipal LoginMember loginMember, @PathVariable Long favoriteId){
+        favoriteService.deleteFavorite(loginMember, favoriteId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/nextstep/subway/station/application/StationService.java
+++ b/src/main/java/nextstep/subway/station/application/StationService.java
@@ -1,5 +1,6 @@
 package nextstep.subway.station.application;
 
+import nextstep.subway.exception.NotExistsStationException;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 import nextstep.subway.station.dto.StationRequest;
@@ -42,6 +43,6 @@ public class StationService {
     }
 
     public Station findById(Long id) {
-        return stationRepository.findById(id).orElseThrow(RuntimeException::new);
+        return stationRepository.findById(id).orElseThrow(NotExistsStationException::new);
     }
 }

--- a/src/test/java/nextstep/subway/auth/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/AuthAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.member.dto.MemberRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("Session 로그인 후 내 정보 조회")
     @Test
     void myInfoWithSession() {
-        회원_생성_요청(EMAIL, PASSWORD, AGE);
+        회원_생성_요청(new MemberRequest(EMAIL, PASSWORD, AGE));
 
         ExtractableResponse<Response> response = 내_회원_정보_조회_요청(EMAIL, PASSWORD);
 
@@ -27,7 +28,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("Bearer Auth")
     @Test
     void myInfoWithBearerAuth() {
-        회원_생성_요청(EMAIL, PASSWORD, AGE);
+        회원_생성_요청(new MemberRequest(EMAIL, PASSWORD, AGE));
         TokenResponse tokenResponse = 로그인_되어_있음(EMAIL, PASSWORD);
 
         ExtractableResponse<Response> response = 내_회원_정보_조회_요청(tokenResponse);

--- a/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -24,6 +24,7 @@ import static nextstep.subway.member.MemberSteps.로그인_되어_있음;
 import static nextstep.subway.member.MemberSteps.회원_등록되어_있음;
 import static nextstep.subway.station.StationSteps.지하철역_등록되어_있음;
 
+@DisplayName("즐겨찾기 관리 인수테스트")
 public class FavoriteAcceptanceTest extends AcceptanceTest {
 
     private static final String EMAIL = "email@email.com";

--- a/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,76 @@
+package nextstep.subway.favorite.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
+import nextstep.subway.member.dto.MemberRequest;
+import nextstep.subway.station.dto.StationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.subway.favorite.steps.FavoriteSteps.*;
+import static nextstep.subway.line.acceptance.LineSteps.지하철_노선_등록되어_있음;
+import static nextstep.subway.line.acceptance.LineSteps.지하철_노선에_지하철역_등록됨;
+import static nextstep.subway.member.MemberSteps.로그인_되어_있음;
+import static nextstep.subway.member.MemberSteps.회원_등록되어_있음;
+import static nextstep.subway.station.StationSteps.지하철역_등록되어_있음;
+
+public class FavoriteAcceptanceTest extends AcceptanceTest {
+
+    private static final String EMAIL = "email@email.com";
+    private static final String PASSWORD = "password";
+    private static final int AGE = 20;
+    private static StationResponse 강남역, 역삼역, 선릉역;
+    LineResponse 이호선;
+    TokenResponse tokenResponse;
+    private Map<String, String> params = new HashMap<>();
+
+    @BeforeEach
+    public void setUp(){
+        super.setUp();
+        // given
+        강남역 = 지하철역_등록되어_있음("강남역").as(StationResponse.class);
+        역삼역 = 지하철역_등록되어_있음("역삼역").as(StationResponse.class);
+        선릉역 = 지하철역_등록되어_있음("선릉역").as(StationResponse.class);
+
+        이호선 = 지하철_노선_등록되어_있음(new LineRequest("2호선", "green", 강남역.getId(), 역삼역.getId(), 10)).as(LineResponse.class);
+        지하철_노선에_지하철역_등록됨(이호선, new SectionRequest(역삼역.getId(), 선릉역.getId(), 5));
+
+        회원_등록되어_있음(new MemberRequest(EMAIL, PASSWORD, AGE)); // Location : memberId
+        tokenResponse = 로그인_되어_있음(EMAIL, PASSWORD);
+
+        params.put("source", 강남역.getId() + "");
+        params.put("target", 선릉역.getId() + "");
+    }
+
+    @DisplayName("즐겨찾기를 생성/조회/삭제")
+    @Test
+    void manageFavorite(){
+
+        // when
+        ExtractableResponse<Response> createResponse = 즐겨찾기_생성_요청(tokenResponse, params);
+
+        // then
+        Long createdId = 즐겨찾기_생성됨(createResponse);
+
+        // when
+        ExtractableResponse<Response> response = 즐겨찾기_목록_조회_요청(tokenResponse);
+
+        // then
+        즐겨찾기_목록_조회됨(response, createdId);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청됨(tokenResponse, createdId);
+
+        // then
+        즐겨찾기_삭제됨(deleteResponse);
+    }
+}

--- a/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
+++ b/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
@@ -11,12 +11,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Transactional
 @SpringBootTest
 class FavoriteServiceTest {
 
@@ -97,7 +99,7 @@ class FavoriteServiceTest {
         // when + then
         assertThatThrownBy(() -> {
             favoriteService.checkFavoriteOfMine(1L, 2L);
-        }).isInstanceOf(RuntimeException.class);
+        }).isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("[예외처리] 존재하지 않는 즐겨찾기 제거")

--- a/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
+++ b/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
@@ -1,5 +1,6 @@
 package nextstep.subway.favorite.application;
 
+import nextstep.subway.exception.NotExistsFavoriteException;
 import nextstep.subway.exception.NotExistsStationException;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
@@ -71,7 +72,7 @@ class FavoriteServiceTest {
                 .doesNotContain(양재역.getId());
 
         // when 즐겨찾기 삭제
-        favoriteService.deleteFavorite(USER, favorites.get(0).getId());
+        favoriteService.deleteFavoriteOfMine(USER, favorites.get(0).getId());
         favorites = favoriteService.findFavorites(USER);
 
         // then
@@ -93,22 +94,13 @@ class FavoriteServiceTest {
         }).isInstanceOf(NotExistsStationException.class);
     }
 
-    @DisplayName("[예외처리] 로그인한 계정의 즐겨찾기가 아니면 예외발생")
-    @Test
-    void checkFavoriteOfMine(){
-        // when + then
-        assertThatThrownBy(() -> {
-            favoriteService.checkFavoriteOfMine(1L, 2L);
-        }).isInstanceOf(IllegalArgumentException.class);
-    }
-
     @DisplayName("[예외처리] 존재하지 않는 즐겨찾기 제거")
     @Test
     void deleteFavoriteWithNotExistsFavorite(){
         // when + then
         assertThatThrownBy(() -> {
-            favoriteService.deleteFavorite(USER, 100L);
-        }).isInstanceOf(RuntimeException.class);
+            favoriteService.deleteFavoriteOfMine(USER, 100L);
+        }).isInstanceOf(NotExistsFavoriteException.class);
     }
 
 }

--- a/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
+++ b/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
@@ -1,0 +1,112 @@
+package nextstep.subway.favorite.application;
+
+import nextstep.subway.exception.NotExistsStationException;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.LoginMember;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class FavoriteServiceTest {
+
+    @Autowired
+    FavoriteService favoriteService;
+
+    @Autowired
+    StationRepository stationRepository;
+
+    private static final LoginMember USER = new LoginMember(1L, "email@email.com", "qwer123", 20);
+    private Station 강남역, 역삼역, 양재역;
+    private FavoriteRequest favoriteRequest;
+
+    @BeforeEach
+    void setUp(){
+        // given
+        강남역 = new Station("강남역");
+        역삼역 = new Station("역삼역");
+        양재역 = new Station("양재역");
+        saveStations(강남역, 역삼역, 양재역);
+        favoriteRequest = new FavoriteRequest(강남역.getId(), 역삼역.getId());
+    }
+
+    void saveStations(Station ... stations){
+        for(Station station : stations){
+            stationRepository.save(station);
+        }
+    }
+
+    @DisplayName("즐겨찾기 등록/조회/삭제 테스트")
+    @Test
+    void manageFavoriteTest(){
+
+        // when 즐겨찾기 등록
+        FavoriteResponse favorite = favoriteService.createFavorite(USER, favoriteRequest);
+
+        // then
+        assertThat(favorite.getSource().getId()).isEqualTo(강남역.getId());
+        assertThat(favorite.getTarget().getId()).isEqualTo(역삼역.getId());
+
+        // when 즐겨찾기 조회
+        List<FavoriteResponse> favorites = favoriteService.findFavorites(USER);
+
+        // then
+        assertThat(favorites)
+                .map(it -> it.getSource().getId())
+                .contains(강남역.getId());
+        assertThat(favorites)
+                .map(it -> it.getSource().getId())
+                .doesNotContain(양재역.getId());
+
+        // when 즐겨찾기 삭제
+        favoriteService.deleteFavorite(USER, favorites.get(0).getId());
+        favorites = favoriteService.findFavorites(USER);
+
+        // then
+        assertThat(favorites)
+                .map(it -> it.getSource().getId())
+                .doesNotContain(강남역.getId());
+
+    }
+
+    @DisplayName("[예외처리] 존재하지 않는 역 아이디 등록")
+    @Test
+    void createFavoriteWithNotExistsStation(){
+        // given
+        favoriteRequest = new FavoriteRequest(100L, 역삼역.getId());
+
+        // when + then
+        assertThatThrownBy(() -> {
+            favoriteService.createFavorite(USER, favoriteRequest);
+        }).isInstanceOf(NotExistsStationException.class);
+    }
+
+    @DisplayName("[예외처리] 로그인한 계정의 즐겨찾기가 아니면 예외발생")
+    @Test
+    void checkFavoriteOfMine(){
+        // when + then
+        assertThatThrownBy(() -> {
+            favoriteService.checkFavoriteOfMine(1L, 2L);
+        }).isInstanceOf(RuntimeException.class);
+    }
+
+    @DisplayName("[예외처리] 존재하지 않는 즐겨찾기 제거")
+    @Test
+    void deleteFavoriteWithNotExistsFavorite(){
+        // when + then
+        assertThatThrownBy(() -> {
+            favoriteService.deleteFavorite(USER, 100L);
+        }).isInstanceOf(RuntimeException.class);
+    }
+
+}

--- a/src/test/java/nextstep/subway/favorite/steps/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/favorite/steps/FavoriteSteps.java
@@ -1,0 +1,60 @@
+package nextstep.subway.favorite.steps;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.auth.dto.TokenResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FavoriteSteps {
+
+    public static ExtractableResponse<Response> 즐겨찾기_생성_요청(TokenResponse tokenResponse, Map<String, String> params) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when()
+                .post("/favorites")
+                .then().log().all().extract();
+    }
+
+    public static Long 즐겨찾기_생성됨(ExtractableResponse<Response> createResponse) {
+        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        return Long.parseLong(createResponse.header("Location").split("/")[2]);
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_목록_조회_요청(TokenResponse tokenResponse) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/favorites")
+                .then().log().all().extract();
+    }
+
+    public static void 즐겨찾기_목록_조회됨(ExtractableResponse<Response> response, Long createdId) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getLong("id")).isEqualTo(createdId);
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_삭제_요청됨(TokenResponse tokenResponse, Long createdId) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .when()
+                .delete("/favorites/" + createdId)
+                .then().log().all().extract();
+    }
+
+    public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> deleteResponse) {
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+}

--- a/src/test/java/nextstep/subway/line/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.line.acceptance;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
     private StationResponse 강남역;
     private StationResponse 광교역;
     private Map<String, String> lineCreateParams;
+    private LineRequest 신분당선;
 
     @BeforeEach
     public void setUp() {
@@ -34,19 +36,14 @@ public class LineAcceptanceTest extends AcceptanceTest {
         강남역 = 지하철역_등록되어_있음("강남역").as(StationResponse.class);
         광교역 = 지하철역_등록되어_있음("광교역").as(StationResponse.class);
 
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", "신분당선");
-        lineCreateParams.put("color", "bg-red-600");
-        lineCreateParams.put("upStationId", 강남역.getId() + "");
-        lineCreateParams.put("downStationId", 광교역.getId() + "");
-        lineCreateParams.put("distance", 10 + "");
+        신분당선 = new LineRequest("신분당선", "bg-red-600", 강남역.getId(), 광교역.getId(), 10);
     }
 
     @DisplayName("지하철 노선을 생성한다.")
     @Test
     void createLine() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청(lineCreateParams);
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(신분당선);
 
         // then
         지하철_노선_생성됨(response);
@@ -56,14 +53,9 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "구분당선");
-        params.put("color", "bg-red-600");
-        params.put("upStationId", 강남역.getId() + "");
-        params.put("downStationId", 광교역.getId() + "");
-        params.put("distance", 15 + "");
-        ExtractableResponse<Response> createResponse1 = 지하철_노선_등록되어_있음(params);
-        ExtractableResponse<Response> createResponse2 = 지하철_노선_등록되어_있음(lineCreateParams);
+        LineRequest 구분당선 = new LineRequest("구분당선", "bg-red-600", 강남역.getId(), 광교역.getId(), 15);
+        ExtractableResponse<Response> createResponse1 = 지하철_노선_등록되어_있음(구분당선);
+        ExtractableResponse<Response> createResponse2 = 지하철_노선_등록되어_있음(신분당선);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
@@ -77,7 +69,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음(lineCreateParams);
+        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음(신분당선);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
@@ -91,7 +83,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
     void updateLine() {
         // given
         String name = "신분당선";
-        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음(lineCreateParams);
+        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음(신분당선);
 
         // when
         Map<String, String> params = new HashMap<>();
@@ -110,7 +102,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음(lineCreateParams);
+        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음(신분당선);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_제거_요청(createResponse);
@@ -123,10 +115,10 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLineWithDuplicateName() {
         // given
-        지하철_노선_등록되어_있음(lineCreateParams);
+        지하철_노선_등록되어_있음(신분당선);
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청(lineCreateParams);
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(신분당선);
 
         // then
         지하철_노선_생성_실패됨(response);

--- a/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
@@ -3,7 +3,9 @@ package nextstep.subway.line.acceptance;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,9 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static nextstep.subway.line.acceptance.LineSteps.*;
@@ -37,21 +37,15 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
         정자역 = 지하철역_등록되어_있음("정자역").as(StationResponse.class);
         광교역 = 지하철역_등록되어_있음("광교역").as(StationResponse.class);
 
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", "신분당선");
-        lineCreateParams.put("color", "bg-red-600");
-        lineCreateParams.put("upStationId", 강남역.getId() + "");
-        lineCreateParams.put("downStationId", 양재역.getId() + "");
-        lineCreateParams.put("distance", 10 + "");
-        신분당선 = 지하철_노선_등록되어_있음(lineCreateParams).as(LineResponse.class);
+        LineRequest lineRequest = new LineRequest("신분당선", "bg-red-600", 강남역.getId(), 양재역.getId(), 10);
+        신분당선 = 지하철_노선_등록되어_있음(lineRequest).as(LineResponse.class);
     }
 
     @DisplayName("지하철 노선에 구간을 등록한다.")
     @Test
     void addLineSection() {
         // when
-        지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 6);
+        지하철_노선에_지하철역_등록_요청(신분당선, new SectionRequest(양재역.getId(), 정자역.getId(), 6));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -62,10 +56,10 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선에 이미 포함된 역을 구간으로 등록한다.")
     @Test
     void addLineSectionAlreadyIncluded() {// given
-        지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 6);
+        지하철_노선에_지하철역_등록_요청(신분당선, new SectionRequest(양재역.getId(), 정자역.getId(), 6));
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 6);
+        ExtractableResponse<Response> response = 지하철_노선에_지하철역_등록_요청(신분당선, new SectionRequest(양재역.getId(), 정자역.getId(), 6));
 
         // then
         지하철_노선에_지하철역_등록_실패됨(response);
@@ -75,7 +69,7 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection() {
         // given
-        지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 6);
+        지하철_노선에_지하철역_등록_요청(신분당선, new SectionRequest(양재역.getId(), 정자역.getId(), 6));
 
         // when
         ExtractableResponse<Response> removeResponse = 지하철_노선에_지하철역_제외_요청(신분당선, 정자역);

--- a/src/test/java/nextstep/subway/line/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSteps.java
@@ -3,23 +3,24 @@ package nextstep.subway.line.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
 import nextstep.subway.station.dto.StationResponse;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class LineSteps {
 
-    public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(Map<String, String> params) {
-        return 지하철_노선_생성_요청(params);
+    public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(LineRequest lineRequest) {
+        return 지하철_노선_생성_요청(lineRequest);
     }
 
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> params) {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(LineRequest lineRequest) {
         return RestAssured.given().log().all().
                 contentType(MediaType.APPLICATION_JSON_VALUE).
-                body(params).
+                body(lineRequest).
                 when().
                 post("/lines").
                 then().
@@ -83,15 +84,13 @@ public class LineSteps {
                 extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록_요청(LineResponse line, StationResponse upStation, StationResponse downStation, int distance) {
-        Map<String, String> params = new HashMap<>();
-        params.put("upStationId", upStation.getId() + "");
-        params.put("downStationId", downStation.getId() + "");
-        params.put("distance", distance + "");
-
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록됨(LineResponse line, SectionRequest sectionRequest) {
+        return 지하철_노선에_지하철역_등록_요청(line, sectionRequest);
+    }
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록_요청(LineResponse line, SectionRequest sectionRequest) {
         return RestAssured.given().log().all().
                 contentType(MediaType.APPLICATION_JSON_VALUE).
-                body(params).
+                body(sectionRequest).
                 when().
                 post("/lines/{lineId}/sections", line.getId()).
                 then().

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -17,12 +17,13 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     public static final String NEW_PASSWORD = "newpassword";
     public static final int AGE = 20;
     public static final int NEW_AGE = 21;
+    public static final MemberRequest 신규회원 = new MemberRequest(EMAIL, PASSWORD, AGE);
 
     @DisplayName("회원가입을 한다.")
     @Test
     void createMember() {
         // when
-        ExtractableResponse<Response> response = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> response = 회원_생성_요청(신규회원);
 
         // then
         회원_생성됨(response);
@@ -32,7 +33,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void getMember() {
         // given
-        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(신규회원);
 
         // when
         ExtractableResponse<Response> response = 회원_정보_조회_요청(createResponse);
@@ -46,7 +47,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void updateMember() {
         // given
-        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(신규회원);
 
         // when
         ExtractableResponse<Response> response = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
@@ -59,7 +60,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteMember() {
         // given
-        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(신규회원);
 
         // when
         ExtractableResponse<Response> response = 회원_삭제_요청(createResponse);
@@ -72,7 +73,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void manageMember() {
         //when
-        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(신규회원);
         //then
         회원_생성됨(createResponse);
 
@@ -97,7 +98,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void manageMyInfo() {
         // given
-        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(신규회원);
         회원_생성됨(createResponse);
 
         TokenResponse tokenResponse = 로그인_되어_있음(EMAIL, PASSWORD);

--- a/src/test/java/nextstep/subway/member/MemberSteps.java
+++ b/src/test/java/nextstep/subway/member/MemberSteps.java
@@ -37,16 +37,15 @@ public class MemberSteps {
                 .statusCode(HttpStatus.OK.value()).extract();
     }
 
-    public static ExtractableResponse<Response> 회원_생성_요청(String email, String password, Integer age) {
-        Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("password", password);
-        params.put("age", age + "");
+    public static ExtractableResponse<Response> 회원_등록되어_있음(MemberRequest memberRequest) {
+        return 회원_생성_요청(memberRequest);
+    }
 
+    public static ExtractableResponse<Response> 회원_생성_요청(MemberRequest memberRequest) {
         return RestAssured
                 .given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
+                .body(memberRequest)
                 .when().post("/members")
                 .then().log().all().extract();
     }

--- a/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
@@ -5,7 +5,9 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
 import nextstep.subway.path.dto.PathResponse;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,9 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static nextstep.subway.line.acceptance.LineSteps.지하철_노선_생성_요청;
@@ -42,11 +42,11 @@ public class PathAcceptanceTest extends AcceptanceTest {
         양재역 = 지하철역_등록되어_있음("양재역").as(StationResponse.class);
         남부터미널역 = 지하철역_등록되어_있음("남부터미널역").as(StationResponse.class);
 
-        이호선 = 지하철_노선_등록되어_있음("2호선", "green", 교대역, 강남역, 10);
-        신분당선 = 지하철_노선_등록되어_있음("신분당선", "green", 강남역, 양재역, 10);
-        삼호선 = 지하철_노선_등록되어_있음("3호선", "green", 교대역, 남부터미널역, 2);
+        이호선 = 지하철_노선_등록되어_있음(new LineRequest("2호선", "green", 교대역.getId(), 강남역.getId(), 10));
+        신분당선 = 지하철_노선_등록되어_있음(new LineRequest("신분당선", "green", 강남역.getId(), 양재역.getId(), 10));
+        삼호선 = 지하철_노선_등록되어_있음(new LineRequest("3호선", "green", 교대역.getId(), 남부터미널역.getId(), 2));
 
-        지하철_노선에_지하철역_등록_요청(삼호선, 남부터미널역, 양재역, 3);
+        지하철_노선에_지하철역_등록_요청(삼호선, new SectionRequest(남부터미널역.getId(), 양재역.getId(), 3));
     }
 
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
@@ -59,14 +59,8 @@ public class PathAcceptanceTest extends AcceptanceTest {
         최단_거리_경로_응답됨(response);
     }
 
-    private LineResponse 지하철_노선_등록되어_있음(String name, String color, StationResponse upStation, StationResponse downStation, int distance) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", name);
-        params.put("color", color);
-        params.put("upStationId", upStation.getId() + "");
-        params.put("downStationId", downStation.getId() + "");
-        params.put("distance", distance + "");
-        return 지하철_노선_생성_요청(params).as(LineResponse.class);
+    private LineResponse 지하철_노선_등록되어_있음(LineRequest lineRequest) {
+        return 지하철_노선_생성_요청(lineRequest).as(LineResponse.class);
     }
 
     private ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(Long source, Long target) {


### PR DESCRIPTION
안녕하세요~! 🙇
3주차 3단계 pr리뷰 요청 드립니다~
한가지 질문 사항이 있어 추가로 남겨봅니다! 🧐
감사합니다! 🙏

### 요구사항
- [ ] 즐겨 찾기 기능을 구현하기
- [ ] 로그인이 필요한 API 요청 시 유효하지 않은 경우 401 응답 내려주기

### 질문사항
Favorite객체에서 Station과 Member의 아이디만 으로 약한 결합(?) 을 통해 소스를 작성하였는데요.
이런경우, cascade 옵션을 줄수 없다고 생각되는데요. 👀
그렇다면, Station이 제거 될때, 이를 포함하는 Favorite을 제거하는 로직을 따로 구현해야할까요?...
아니면, stationService.findById()에서 현재 예외를 던지고 있는데, Favorite조회시에 해당 예외발생시..지운다던지 or 스킵한다던지..
Station제거시 Favorite을 제거 하는 로직을 주는게 제일 간결(?)해 보이기는 하는데, 이런 상황의 경우 어떤 식으로 처리 되는지 궁금하여 질문 남깁니당! 🧐🧐🧐