### PR TITLE
1단계 - 토큰 기반 로그인 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ npm run dev
 ```
 ./gradlew bootRun
 ```
+
+# 💻 로그인 인증 프로세스 실습
+- MemberAcceptanceTest의 인수 테스트 통합하기
+- AuthAcceptanceTest의 myInfoWithSession 테스트 메서드를 성공 시키기

--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ npm run dev
 # 💻 로그인 인증 프로세스 실습
 - MemberAcceptanceTest의 인수 테스트 통합하기
 - AuthAcceptanceTest의 myInfoWithSession 테스트 메서드를 성공 시키기
+
+# 🚀 1단계 - 토큰 기반 로그인 구현
+- AuthAcceptanceTest의 myInfoWithBearerAuth 테스트 메서드를 성공 시키기
+  - TokenAuthenticationInterceptor 구현하기
+- MemberAcceptanceTest의 manageMyInfo 성공 시키기
+  - @AuthenticationPrincipal을 활용하여 로그인 정보 받아오기

--- a/src/main/java/nextstep/auth/authentication/AuthenticationException.java
+++ b/src/main/java/nextstep/auth/authentication/AuthenticationException.java
@@ -5,4 +5,11 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.UNAUTHORIZED)
 public class AuthenticationException extends RuntimeException {
+
+	public static final String NOT_FOUND_EMAIL = "Not found user email";
+	public static final String PASSWORD_IS_INCORRECT = "Password is incorrect";
+
+	public AuthenticationException(String message) {
+		super(message);
+	}
 }

--- a/src/main/java/nextstep/auth/authentication/SessionAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/SessionAuthenticationInterceptor.java
@@ -11,6 +11,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.Map;
 
+import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
+import static nextstep.auth.authentication.AuthenticationException.PASSWORD_IS_INCORRECT;
 import static nextstep.auth.context.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
 public class SessionAuthenticationInterceptor implements HandlerInterceptor {
@@ -52,11 +54,11 @@ public class SessionAuthenticationInterceptor implements HandlerInterceptor {
 
     private void checkAuthentication(LoginMember userDetails, AuthenticationToken token) {
         if (userDetails == null) {
-            throw new AuthenticationException();
+			throw new AuthenticationException(NOT_FOUND_EMAIL);
         }
 
         if (!userDetails.checkPassword(token.getCredentials())) {
-            throw new AuthenticationException();
+			throw new AuthenticationException(PASSWORD_IS_INCORRECT);
         }
     }
 }

--- a/src/main/java/nextstep/auth/token/TokenResponse.java
+++ b/src/main/java/nextstep/auth/token/TokenResponse.java
@@ -1,16 +1,31 @@
 package nextstep.auth.token;
 
+import java.util.Objects;
+
 public class TokenResponse {
-    private String accessToken;
+	private String accessToken;
 
-    public TokenResponse() {
-    }
+	public TokenResponse() {
+	}
 
-    public TokenResponse(String accessToken) {
-        this.accessToken = accessToken;
-    }
+	public TokenResponse(String accessToken) {
+		this.accessToken = accessToken;
+	}
 
-    public String getAccessToken() {
-        return accessToken;
-    }
+	public String getAccessToken() {
+		return accessToken;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof TokenResponse)) return false;
+		TokenResponse that = (TokenResponse) o;
+		return Objects.equals(accessToken, that.accessToken);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(accessToken);
+	}
 }

--- a/src/main/java/nextstep/member/application/CustomUserDetailsService.java
+++ b/src/main/java/nextstep/member/application/CustomUserDetailsService.java
@@ -1,9 +1,12 @@
 package nextstep.member.application;
 
+import nextstep.auth.authentication.AuthenticationException;
 import nextstep.member.domain.LoginMember;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
+
+import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
 
 @Service
 public class CustomUserDetailsService {
@@ -14,7 +17,9 @@ public class CustomUserDetailsService {
     }
 
     public LoginMember loadUserByUsername(String email) {
-        Member member = memberRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthenticationException(NOT_FOUND_EMAIL));
+
         return LoginMember.of(member);
     }
 }

--- a/src/main/java/nextstep/member/application/dto/MemberResponse.java
+++ b/src/main/java/nextstep/member/application/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package nextstep.member.application.dto;
 
+import nextstep.member.domain.LoginMember;
 import nextstep.member.domain.Member;
 
 public class MemberResponse {
@@ -18,6 +19,10 @@ public class MemberResponse {
 
     public static MemberResponse of(Member member) {
         return new MemberResponse(member.getId(), member.getEmail(), member.getAge());
+    }
+
+    public static MemberResponse of(LoginMember loginMember) {
+        return new MemberResponse(loginMember.getId(), loginMember.getEmail(), loginMember.getAge());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/member/ui/MemberController.java
+++ b/src/main/java/nextstep/member/ui/MemberController.java
@@ -1,8 +1,10 @@
 package nextstep.member.ui;
 
+import nextstep.auth.authorization.AuthenticationPrincipal;
 import nextstep.member.application.MemberService;
 import nextstep.member.application.dto.MemberRequest;
 import nextstep.member.application.dto.MemberResponse;
+import nextstep.member.domain.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,8 +43,8 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        return ResponseEntity.ok(MemberResponse.of(loginMember));
     }
 
     @PutMapping("/members/me")

--- a/src/main/java/nextstep/member/ui/MemberController.java
+++ b/src/main/java/nextstep/member/ui/MemberController.java
@@ -48,12 +48,15 @@ public class MemberController {
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine() {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember,
+                                                             @RequestBody MemberRequest param) {
+        memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine() {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/MemberAcceptanceTest.java
@@ -105,5 +105,28 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {
+        // when
+        ExtractableResponse<Response> 회원_생성_응답 = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        // then
+        회원_생성됨(회원_생성_응답);
+
+        // given
+        String accessToken = 로그인_되어_있음(EMAIL, PASSWORD);
+        // when
+        ExtractableResponse<Response> 내_회원_조회_응답 = 내_회원_정보_조회_요청(accessToken);
+        // then
+        회원_정보_조회됨(내_회원_조회_응답, EMAIL, AGE);
+
+        // when
+        ExtractableResponse<Response> 내_회원_수정_응답
+                = 내_회원_정보_수정_요청(회원_생성_응답, accessToken, "new" + EMAIL, "new" + PASSWORD, AGE);
+        // then
+        회원_정보_수정됨(내_회원_수정_응답);
+
+        // when
+        ExtractableResponse<Response> 내_회원_삭제_응답 = 내_회원_정보_삭제_요청(회원_생성_응답, accessToken);
+        // then
+        회원_삭제됨(내_회원_삭제_응답);
     }
+
 }

--- a/src/test/java/nextstep/subway/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/MemberAcceptanceTest.java
@@ -4,10 +4,8 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
 import static nextstep.subway.acceptance.MemberSteps.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class MemberAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "email@email.com";
@@ -21,7 +19,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 회원_생성_요청(EMAIL, PASSWORD, AGE);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        회원_생성됨(response);
     }
 
     @DisplayName("회원 정보를 조회한다.")
@@ -48,7 +46,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 회원_정보_수정_요청(createResponse, "new" + EMAIL, "new" + PASSWORD, AGE);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        회원_정보_수정됨(response);
+
     }
 
     @DisplayName("회원 정보를 삭제한다.")
@@ -61,14 +60,48 @@ class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 회원_삭제_요청(createResponse);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        회원_삭제됨(response);
     }
 
+    /**
+     * Scenario: 회원 정보를 관리
+     * When 회원 생성을 요청
+     * Then 회원 생성됨
+     * When 회원 정보 조회 요청
+     * Then 회원 정보 조회됨
+     * When 회원 정보 수정 요청
+     * Then 회원 정보 수정됨
+     * When 회원 삭제 요청
+     * Then 회원 삭제됨
+     */
     @DisplayName("회원 정보를 관리한다.")
     @Test
     void manageMember() {
+        ExtractableResponse<Response> 회원_생성_응답 = 회원_생성_요청(EMAIL, PASSWORD, AGE);
+        회원_생성됨(회원_생성_응답);
+
+        ExtractableResponse<Response> 회원_조회_응답 = 회원_정보_조회_요청(회원_생성_응답);
+        회원_정보_조회됨(회원_조회_응답, EMAIL, AGE);
+
+        ExtractableResponse<Response> 회원_수정_응답 = 회원_정보_수정_요청(회원_생성_응답, "new" + EMAIL, "new" + PASSWORD, AGE);
+        회원_정보_수정됨(회원_수정_응답);
+
+        ExtractableResponse<Response> 회원_삭제_응답 = 회원_삭제_요청(회원_생성_응답);
+        회원_삭제됨(회원_삭제_응답);
     }
 
+
+    /**
+     * Scenario: 나의 회원 정보를 관리
+     * When 나의 회원 정보 생성을 요청
+     * Then 나의 회원 정보 생성됨
+     * When 나의 회원 정보 조회 요청
+     * Then 나의 회원 정보 조회됨
+     * When 나의 회원 정보 수정 요청
+     * Then 나의 회원 정보 수정됨
+     * When 나의 회원 삭제 요청
+     * Then 나의 회원 삭제됨
+     */
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {

--- a/src/test/java/nextstep/subway/acceptance/MemberSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/MemberSteps.java
@@ -107,4 +107,16 @@ public class MemberSteps {
         assertThat(response.jsonPath().getString("email")).isEqualTo(email);
         assertThat(response.jsonPath().getInt("age")).isEqualTo(age);
     }
+
+    public static void 회원_생성됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    public static void 회원_정보_수정됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 회원_삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/MemberSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/MemberSteps.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemberSteps {
+    final static String LOCATION_HEADER = "Location";
+
     public static final String USERNAME_FIELD = "username";
     public static final String PASSWORD_FIELD = "password";
 
@@ -22,9 +24,7 @@ public class MemberSteps {
     }
 
     public static ExtractableResponse<Response> 로그인_요청(String email, String password) {
-        Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("password", password);
+        Map<String, String> params = createLoginParameters(email, password);
 
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -35,10 +35,7 @@ public class MemberSteps {
     }
 
     public static ExtractableResponse<Response> 회원_생성_요청(String email, String password, Integer age) {
-        Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("password", password);
-        params.put("age", age + "");
+        Map<String, String> params = createParameters(email, password, age);
 
         return RestAssured
                 .given().log().all()
@@ -49,7 +46,7 @@ public class MemberSteps {
     }
 
     public static ExtractableResponse<Response> 회원_정보_조회_요청(ExtractableResponse<Response> response) {
-        String uri = response.header("Location");
+        String uri = getRequestUri(response);
 
         return RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -59,12 +56,9 @@ public class MemberSteps {
     }
 
     public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email, String password, Integer age) {
-        String uri = response.header("Location");
+        String uri = getRequestUri(response);
 
-        Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("password", password);
-        params.put("age", age + "");
+        Map<String, String> params = createParameters(email, password, age);
 
         return RestAssured
                 .given().log().all()
@@ -75,7 +69,7 @@ public class MemberSteps {
     }
 
     public static ExtractableResponse<Response> 회원_삭제_요청(ExtractableResponse<Response> response) {
-        String uri = response.header("Location");
+        String uri = getRequestUri(response);
         return RestAssured
                 .given().log().all()
                 .when().delete(uri)
@@ -102,6 +96,34 @@ public class MemberSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 내_회원_정보_삭제_요청(ExtractableResponse<Response> response, String accessToken) {
+        String uri = getRequestUri(response);
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .when().delete(uri)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 내_회원_정보_수정_요청(ExtractableResponse<Response> response, String accessToken, String email, String password, int age) {
+        String uri = getRequestUri(response);
+
+        Map<String, String> params = createParameters(email, password, age);
+
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().put(uri)
+                .then().log().all().extract();
+
+    }
+
+    private static String getRequestUri(ExtractableResponse<Response> response) {
+        return response.header(LOCATION_HEADER);
+    }
+
     public static void 회원_정보_조회됨(ExtractableResponse<Response> response, String email, int age) {
         assertThat(response.jsonPath().getString("id")).isNotNull();
         assertThat(response.jsonPath().getString("email")).isEqualTo(email);
@@ -118,5 +140,23 @@ public class MemberSteps {
 
     public static void 회원_삭제됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+
+    private static Map<String, String> createLoginParameters(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        return params;
+    }
+
+    private static Map<String, String> createParameters(String email, String password, int age) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+        params.put("age", age + "");
+
+        return params;
     }
 }

--- a/src/test/java/nextstep/subway/unit/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/unit/TokenAuthenticationInterceptorTest.java
@@ -1,27 +1,130 @@
 package nextstep.subway.unit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.auth.authentication.AuthenticationException;
+import nextstep.auth.authentication.AuthenticationToken;
+import nextstep.auth.authentication.TokenAuthenticationInterceptor;
+import nextstep.auth.context.Authentication;
+import nextstep.auth.token.JwtTokenProvider;
 import nextstep.auth.token.TokenRequest;
+import nextstep.auth.token.TokenResponse;
+import nextstep.member.application.CustomUserDetailsService;
+import nextstep.member.domain.LoginMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("토큰 인증 기능 단위 테스트")
 class TokenAuthenticationInterceptorTest {
     private static final String EMAIL = "email@email.com";
     private static final String PASSWORD = "password";
     public static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno";
 
+    TokenAuthenticationInterceptor tokenAuthenticationInterceptor;
+
+    @Mock
+    CustomUserDetailsService userDetailsService;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        tokenAuthenticationInterceptor = new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider);
+    }
+
     @Test
     void convert() throws IOException {
+        // when
+        AuthenticationToken authenticationToken = tokenAuthenticationInterceptor.convert(createMockRequest());
+
+        // then
+        assertThat(authenticationToken.getPrincipal()).isEqualTo(EMAIL);
+        assertThat(authenticationToken.getCredentials()).isEqualTo(PASSWORD);
     }
 
     @Test
-    void authenticate() {
+    void authenticate() throws IOException {
+        // given
+        AuthenticationToken authenticationToken = tokenAuthenticationInterceptor.convert(createMockRequest());
+        when(userDetailsService.loadUserByUsername(anyString()))
+                .thenReturn(getMockLoginMember(EMAIL, PASSWORD));
+
+        // when
+        Authentication authenticate = tokenAuthenticationInterceptor.authenticate(authenticationToken);
+        LoginMember principal = (LoginMember) authenticate.getPrincipal();
+
+        // then
+        assertThat(principal).isNotNull();
+        assertThat(principal).extracting(LoginMember::getEmail).isEqualTo(EMAIL);
+        assertThat(principal).extracting(LoginMember::getPassword).isEqualTo(PASSWORD);
+    }
+
+    @DisplayName("인증 실패 - email 찾을 수 없음")
+    @Test
+    void authenticateNotFoundEmail() throws IOException {
+        // given
+        AuthenticationToken authenticationToken = tokenAuthenticationInterceptor.convert(createMockRequest());
+        when(userDetailsService.loadUserByUsername(anyString()))
+                .thenReturn(null);
+
+        // when, then
+        assertThatThrownBy(() -> tokenAuthenticationInterceptor.authenticate(authenticationToken))
+                .isInstanceOf(AuthenticationException.class);
+
+    }
+
+    @DisplayName("인증 실패 - password 불일치")
+    @Test
+    void authenticateIncorrectPassword() throws IOException {
+        // given
+        String INCORRECT_PASSWORD = PASSWORD + "-incorrect";
+        AuthenticationToken authenticationToken = tokenAuthenticationInterceptor.convert(createMockRequest());
+        when(userDetailsService.loadUserByUsername(anyString()))
+                .thenReturn(getMockLoginMember(EMAIL, INCORRECT_PASSWORD));
+
+        // when, then
+        assertThatThrownBy(() -> tokenAuthenticationInterceptor.authenticate(authenticationToken))
+                .isInstanceOf(AuthenticationException.class);
     }
 
     @Test
-    void preHandle() throws IOException {
+    void preHandle() throws Exception {
+        // given
+        when(userDetailsService.loadUserByUsername(anyString()))
+                .thenReturn(getMockLoginMember(EMAIL, PASSWORD));
+        when(jwtTokenProvider.createToken(anyString()))
+                .thenReturn(JWT_TOKEN);
+
+        // when
+        MockHttpServletResponse mockResponse = createMockResponse();
+        tokenAuthenticationInterceptor.preHandle(createMockRequest(), mockResponse, new Object());
+
+        // then
+        assertThat(mockResponse.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(getContent(mockResponse)).isEqualTo(getExpectedTokenResponse());
+    }
+
+    private TokenResponse getExpectedTokenResponse() {
+        return new TokenResponse(JWT_TOKEN);
+    }
+
+    private TokenResponse getContent(MockHttpServletResponse mockResponse) throws Exception {
+        return new ObjectMapper().readValue(mockResponse.getContentAsString(), TokenResponse.class);
     }
 
     private MockHttpServletRequest createMockRequest() throws IOException {
@@ -29,6 +132,14 @@ class TokenAuthenticationInterceptorTest {
         TokenRequest tokenRequest = new TokenRequest(EMAIL, PASSWORD);
         request.setContent(new ObjectMapper().writeValueAsString(tokenRequest).getBytes());
         return request;
+    }
+
+    private MockHttpServletResponse createMockResponse() {
+        return new MockHttpServletResponse();
+    }
+
+    private LoginMember getMockLoginMember(String email, String password) {
+        return new LoginMember(0L, email, password, 0);
     }
 
 }


### PR DESCRIPTION
안녕하세요. 박이슬 리뷰어님!
토큰 기반 로그인 구현 완료하였습니다.

궁금한 점 몇 가지가 있습니다.
1.
manageMyInfo 테스트를 먼저 구현하고 프로덕션 코드를 구현하려고 했는데, 
update, delete가 구현이 안된 상태에서도 테스트가 성공하던데, status code 만 보고서 단언문을 처리하여 그런 것 같습니다.
이럴 땐 한번 더 조회 요청을 날려서 수정 혹은 삭제된 정보를 확인을 해야할까요? 아니면 그냥 status code 로만 단언문 처리를 해야할 지 궁금합니다.

2. 
MemberSteps 에 RestAssured 관련 동일한 코드가 반복이 많네요.
메서드 추출을 통해 중복을 없애주려고 했는데, 체이닝 메서드로 연결되다 보니 오히려 더 복잡해지는 문제가 있는 것 같습니다.
이럴 땐 가독성을 위해서 중복을 허용해주는게 좋을까요?

3.
패키지 의존성 문제가 있는 것 같아요.
CustomUserDetailsService 에서 email을 못찾을 경우 UNAUTHORIZED 상태코드를 반환하는 AuthenticationException 예외를 던져주도록 구현을 했습니다.(기존 베이스 코드에는 RuntimeException 예외를 던집니다.)
CustomUserDetailsService 패키지는 member에 위치하고 AuthenticationException 예외는 auth에 위치합니다.
이 경우 양방향 패키지 의존성이 발생하네요.

CustomUserDetailsService 의 인터페이스를 통해 양방향 의존성을 제거하는게 좋을까요?
CustomUserDetailsService 에서 email을 못찾을 경우 UNAUTHORIZED 상태코드를 반환하고 싶은데 어떻게 처리해야할까요? 

