### PR TITLE
2단계 - 인증 로직 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,34 @@ npm run dev
   - TokenAuthenticationInterceptor 구현하기
 - MemberAcceptanceTest의 manageMyInfo 성공 시키기
   - @AuthenticationPrincipal을 활용하여 로그인 정보 받아오기
+  
+
+# 🚀 2단계 - 인증 로직 리팩터링
+1. 1,2단계에서 구현한 인증 로직에 대한 리팩터링
+- AuthenticationConverter 추상화
+  - AuthenticationConverter 인터페이스 생성
+  - SessionAuthenticationConverter 와 TokenAuthenticationConverter 테스트 작성 및 구현
+  - 기존 코드 대체
+  - 전체 테스트 수행 후 실패 테스트 확인
+  - 기존 코드 제거
+- AuthenticationInterceptor 추상화
+  - AuthenticationInterceptor 인터페이스 생성
+  - 기존 코드 및 관련 테스트는 그대로 둠(SessionAuthenticationInterceptor, TokenAuthenticationInterceptor)
+  - TokenAuthenticationInterceptor2 와 SessionAuthenticationInterceptor2 테스트 작성 및 구현
+  - 기존 코드 대체
+  - 전체 테스트 수행 후 실패 테스트 확인
+  - 기존 코드 제거
+- auth 패키지와 member 패키지에 대한 의존 제거
+  - UserDetailsService 인터페이스 생성
+  - CustomUserDetailService 가 UserDetailsService 를 구현하도록 수정
+  - 전체 테스트 수행 후 실패 테스트 확인
+- SecurityContextInterceptor 추상화
+  - SecurityContextInterceptor 인터페이스 생성
+  - 기존 코드 및 관련 테스트는 그대로 둠(SessionSecurityContextPersistenceInterceptor, TokenSecurityContextPersistenceInterceptor)
+  - SessionSecurityContextPersistenceInterceptor2, TokenSecurityContextPersistenceInterceptor2 테스트 작성 및 구현
+  - 기존 코드 대체
+  - 전체 테스트 수행 후 실패 테스트 확인
+  - 기존 코드 제거
+- 내 정보 수정 / 삭제 기능을 처리하는 기능 구현
+  - Controller에서 @ㅐ너테이션을 활용하여 Login 정보에 접근
+  

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run dev
   
 
 # 🚀 2단계 - 인증 로직 리팩터링
-1. 1,2단계에서 구현한 인증 로직에 대한 리팩터링
+### 1. 1,2단계에서 구현한 인증 로직에 대한 리팩터링
 - AuthenticationConverter 추상화
   - AuthenticationConverter 인터페이스 생성
   - SessionAuthenticationConverter 와 TokenAuthenticationConverter 테스트 작성 및 구현
@@ -73,6 +73,7 @@ npm run dev
   - 기존 코드 대체
   - 전체 테스트 수행 후 실패 테스트 확인
   - 기존 코드 제거
-- 내 정보 수정 / 삭제 기능을 처리하는 기능 구현
-  - Controller에서 @ㅐ너테이션을 활용하여 Login 정보에 접근
+
+### 2. 내 정보 수정 / 삭제 기능을 처리하는 기능 구현
+- Controller에서 @ㅐ너테이션을 활용하여 Login 정보에 접근
   

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run dev
   - 기존 코드 대체
   - 전체 테스트 수행 후 실패 테스트 확인
   - 기존 코드 제거
-- auth 패키지와 member 패키지에 대한 의존 제거
+- auth 패키지와 member 패키지의 양방향 의존 제거
   - UserDetailsService 인터페이스 생성
   - CustomUserDetailService 가 UserDetailsService 를 구현하도록 수정
   - 전체 테스트 수행 후 실패 테스트 확인

--- a/src/main/java/nextstep/auth/AuthConfig.java
+++ b/src/main/java/nextstep/auth/AuthConfig.java
@@ -6,8 +6,8 @@ import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authorization.AuthenticationPrincipalArgumentResolver;
 import nextstep.auth.authorization.SessionSecurityContextPersistenceInterceptor;
 import nextstep.auth.authorization.TokenSecurityContextPersistenceInterceptor;
+import nextstep.auth.service.UserDetailsService;
 import nextstep.auth.token.JwtTokenProvider;
-import nextstep.member.application.CustomUserDetailsService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -16,12 +16,12 @@ import java.util.List;
 
 @Configuration
 public class AuthConfig implements WebMvcConfigurer {
-    private final CustomUserDetailsService userDetailsService;
+    private final UserDetailsService userDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationConverter sessionAuthenticationConverter;
     private final AuthenticationConverter tokenAuthenticationConverter;
 
-    public AuthConfig(CustomUserDetailsService userDetailsService,
+    public AuthConfig(UserDetailsService userDetailsService,
                       JwtTokenProvider jwtTokenProvider,
                       AuthenticationConverter sessionAuthenticationConverter,
                       AuthenticationConverter tokenAuthenticationConverter) {

--- a/src/main/java/nextstep/auth/AuthConfig.java
+++ b/src/main/java/nextstep/auth/AuthConfig.java
@@ -2,6 +2,7 @@ package nextstep.auth;
 
 import nextstep.auth.authentication.SessionAuthenticationInterceptor;
 import nextstep.auth.authentication.TokenAuthenticationInterceptor;
+import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authorization.AuthenticationPrincipalArgumentResolver;
 import nextstep.auth.authorization.SessionSecurityContextPersistenceInterceptor;
 import nextstep.auth.authorization.TokenSecurityContextPersistenceInterceptor;
@@ -15,18 +16,29 @@ import java.util.List;
 
 @Configuration
 public class AuthConfig implements WebMvcConfigurer {
-    private CustomUserDetailsService userDetailsService;
-    private JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationConverter sessionAuthenticationConverter;
+    private final AuthenticationConverter tokenAuthenticationConverter;
 
-    public AuthConfig(CustomUserDetailsService userDetailsService, JwtTokenProvider jwtTokenProvider) {
+    public AuthConfig(CustomUserDetailsService userDetailsService,
+                      JwtTokenProvider jwtTokenProvider,
+                      AuthenticationConverter sessionAuthenticationConverter,
+                      AuthenticationConverter tokenAuthenticationConverter) {
         this.userDetailsService = userDetailsService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.sessionAuthenticationConverter = sessionAuthenticationConverter;
+        this.tokenAuthenticationConverter = tokenAuthenticationConverter;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new SessionAuthenticationInterceptor(userDetailsService)).addPathPatterns("/login/session");
-        registry.addInterceptor(new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider)).addPathPatterns("/login/token");
+        registry.addInterceptor(
+                new SessionAuthenticationInterceptor(userDetailsService, sessionAuthenticationConverter))
+                .addPathPatterns("/login/session");
+        registry.addInterceptor(
+                new TokenAuthenticationInterceptor(userDetailsService, jwtTokenProvider, tokenAuthenticationConverter))
+                .addPathPatterns("/login/token");
         registry.addInterceptor(new SessionSecurityContextPersistenceInterceptor());
         registry.addInterceptor(new TokenSecurityContextPersistenceInterceptor(jwtTokenProvider));
     }

--- a/src/main/java/nextstep/auth/authentication/AuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/AuthenticationInterceptor.java
@@ -1,16 +1,56 @@
 package nextstep.auth.authentication;
 
+import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.context.Authentication;
+import nextstep.auth.domain.AuthenticatedMember;
+import nextstep.auth.service.UserDetailsService;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
+import static nextstep.auth.authentication.AuthenticationException.PASSWORD_IS_INCORRECT;
+
 public abstract class AuthenticationInterceptor implements HandlerInterceptor {
+
+	private final UserDetailsService userDetailsService;
+	private final AuthenticationConverter authenticationConverter;
+
+	public AuthenticationInterceptor(UserDetailsService userDetailsService, AuthenticationConverter authenticationConverter) {
+		this.userDetailsService = userDetailsService;
+		this.authenticationConverter = authenticationConverter;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+		AuthenticationToken token = authenticationConverter.convert(request);
+		Authentication authentication = authenticate(token);
+		afterAuthentication(request, response, authentication);
+		return false;
+	}
 
 	public abstract void afterAuthentication(HttpServletRequest request,
 											 HttpServletResponse response,
 											 Authentication authentication) throws IOException;
+
+	protected Authentication authenticate(AuthenticationToken token) {
+		String principal = token.getPrincipal();
+		AuthenticatedMember userDetails = userDetailsService.loadUserByUsername(principal);
+		checkAuthentication(userDetails, token);
+
+		return new Authentication(userDetails);
+	}
+
+	private void checkAuthentication(AuthenticatedMember userDetails, AuthenticationToken token) {
+		if (userDetails == null) {
+			throw new AuthenticationException(NOT_FOUND_EMAIL);
+		}
+
+		if (!userDetails.checkPassword(token.getCredentials())) {
+			throw new AuthenticationException(PASSWORD_IS_INCORRECT);
+		}
+	}
 
 }

--- a/src/main/java/nextstep/auth/authentication/AuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/AuthenticationInterceptor.java
@@ -1,0 +1,16 @@
+package nextstep.auth.authentication;
+
+import nextstep.auth.context.Authentication;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public abstract class AuthenticationInterceptor implements HandlerInterceptor {
+
+	public abstract void afterAuthentication(HttpServletRequest request,
+											 HttpServletResponse response,
+											 Authentication authentication) throws IOException;
+
+}

--- a/src/main/java/nextstep/auth/authentication/SessionAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/SessionAuthenticationInterceptor.java
@@ -3,7 +3,7 @@ package nextstep.auth.authentication;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.context.Authentication;
 import nextstep.auth.context.SecurityContext;
-import nextstep.member.application.CustomUserDetailsService;
+import nextstep.auth.service.UserDetailsService;
 import nextstep.member.domain.LoginMember;
 
 import javax.servlet.http.HttpServletRequest;
@@ -19,10 +19,10 @@ public class SessionAuthenticationInterceptor extends AuthenticationInterceptor 
     public static final String USERNAME_FIELD = "username";
     public static final String PASSWORD_FIELD = "password";
 
-    private final CustomUserDetailsService userDetailsService;
+    private final UserDetailsService userDetailsService;
     private final AuthenticationConverter sessionAuthenticationConverter;
 
-    public SessionAuthenticationInterceptor(CustomUserDetailsService userDetailsService, AuthenticationConverter sessionAuthenticationConverter) {
+    public SessionAuthenticationInterceptor(UserDetailsService userDetailsService, AuthenticationConverter sessionAuthenticationConverter) {
         this.userDetailsService = userDetailsService;
         this.sessionAuthenticationConverter = sessionAuthenticationConverter;
     }

--- a/src/main/java/nextstep/auth/authentication/SessionAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/SessionAuthenticationInterceptor.java
@@ -4,53 +4,21 @@ import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.context.Authentication;
 import nextstep.auth.context.SecurityContext;
 import nextstep.auth.service.UserDetailsService;
-import nextstep.member.domain.LoginMember;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
-import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
-import static nextstep.auth.authentication.AuthenticationException.PASSWORD_IS_INCORRECT;
 import static nextstep.auth.context.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
 public class SessionAuthenticationInterceptor extends AuthenticationInterceptor {
     public static final String USERNAME_FIELD = "username";
     public static final String PASSWORD_FIELD = "password";
 
-    private final UserDetailsService userDetailsService;
-    private final AuthenticationConverter sessionAuthenticationConverter;
 
     public SessionAuthenticationInterceptor(UserDetailsService userDetailsService, AuthenticationConverter sessionAuthenticationConverter) {
-        this.userDetailsService = userDetailsService;
-        this.sessionAuthenticationConverter = sessionAuthenticationConverter;
-    }
-
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
-        AuthenticationToken token = sessionAuthenticationConverter.convert(request);
-        Authentication authentication = authenticate(token);
-        afterAuthentication(request, response, authentication);
-        return false;
-    }
-
-    public Authentication authenticate(AuthenticationToken token) {
-        String principal = token.getPrincipal();
-        LoginMember userDetails = userDetailsService.loadUserByUsername(principal);
-        checkAuthentication(userDetails, token);
-
-        return new Authentication(userDetails);
-    }
-
-    private void checkAuthentication(LoginMember userDetails, AuthenticationToken token) {
-        if (userDetails == null) {
-            throw new AuthenticationException(NOT_FOUND_EMAIL);
-        }
-
-        if (!userDetails.checkPassword(token.getCredentials())) {
-            throw new AuthenticationException(PASSWORD_IS_INCORRECT);
-        }
+        super(userDetailsService, sessionAuthenticationConverter);
     }
 
     @Override

--- a/src/main/java/nextstep/auth/authentication/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/TokenAuthenticationInterceptor.java
@@ -2,14 +2,13 @@ package nextstep.auth.authentication;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.context.Authentication;
 import nextstep.auth.token.JwtTokenProvider;
-import nextstep.auth.token.TokenRequest;
 import nextstep.auth.token.TokenResponse;
 import nextstep.member.application.CustomUserDetailsService;
 import nextstep.member.domain.LoginMember;
 import org.springframework.http.MediaType;
-import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -18,28 +17,42 @@ import java.io.IOException;
 import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
 import static nextstep.auth.authentication.AuthenticationException.PASSWORD_IS_INCORRECT;
 
-public class TokenAuthenticationInterceptor implements HandlerInterceptor {
+public class TokenAuthenticationInterceptor extends AuthenticationInterceptor {
 
-    private CustomUserDetailsService customUserDetailsService;
-    private JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationConverter tokenAuthenticationConverter;
 
-    public TokenAuthenticationInterceptor(CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider) {
+    public TokenAuthenticationInterceptor(CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider, AuthenticationConverter tokenAuthenticationConverter) {
         this.customUserDetailsService = customUserDetailsService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.tokenAuthenticationConverter = tokenAuthenticationConverter;
     }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
-        AuthenticationToken authenticationToken = convert(request);
+        AuthenticationToken authenticationToken = tokenAuthenticationConverter.convert(request);
         Authentication authentication = authenticate(authenticationToken);
 
+        afterAuthentication(request, response, authentication);
+
+        return false;
+    }
+
+    public Authentication authenticate(AuthenticationToken authenticationToken) {
+        LoginMember principal = customUserDetailsService.loadUserByUsername(authenticationToken.getPrincipal());
+        checkCredential(principal, authenticationToken.getCredentials());
+        return new Authentication(principal);
+    }
+
+    @Override
+    public void afterAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         TokenResponse tokenResponse = createTokenResponse(authentication);
 
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getOutputStream().print(convertToResponseToClient(tokenResponse));
 
-        return false;
     }
 
     private String convertToResponseToClient(TokenResponse tokenResponse) throws JsonProcessingException {
@@ -51,20 +64,6 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
         return new TokenResponse(jwtTokenProvider.createToken(payload));
     }
 
-    public AuthenticationToken convert(HttpServletRequest request) throws IOException {
-        TokenRequest tokenRequest = readTokenRequest(request);
-        String principal = tokenRequest.getEmail();
-        String credentials = tokenRequest.getPassword();
-
-        return new AuthenticationToken(principal, credentials);
-    }
-
-    public Authentication authenticate(AuthenticationToken authenticationToken) {
-        LoginMember principal = customUserDetailsService.loadUserByUsername(authenticationToken.getPrincipal());
-        checkCredential(principal, authenticationToken.getCredentials());
-        return new Authentication(principal);
-    }
-
     private void checkCredential(LoginMember principal, String credentials) {
         if (principal == null) {
             throw new AuthenticationException(NOT_FOUND_EMAIL);
@@ -72,9 +71,5 @@ public class TokenAuthenticationInterceptor implements HandlerInterceptor {
         if (!principal.checkPassword(credentials)) {
             throw new AuthenticationException(PASSWORD_IS_INCORRECT);
         }
-    }
-
-    private TokenRequest readTokenRequest(HttpServletRequest request) throws IOException {
-        return new ObjectMapper().readValue(request.getInputStream(), TokenRequest.class);
     }
 }

--- a/src/main/java/nextstep/auth/authentication/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/TokenAuthenticationInterceptor.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.context.Authentication;
+import nextstep.auth.service.UserDetailsService;
 import nextstep.auth.token.JwtTokenProvider;
 import nextstep.auth.token.TokenResponse;
-import nextstep.member.application.CustomUserDetailsService;
 import nextstep.member.domain.LoginMember;
 import org.springframework.http.MediaType;
 
@@ -19,11 +19,11 @@ import static nextstep.auth.authentication.AuthenticationException.PASSWORD_IS_I
 
 public class TokenAuthenticationInterceptor extends AuthenticationInterceptor {
 
-    private final CustomUserDetailsService customUserDetailsService;
+    private final UserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationConverter tokenAuthenticationConverter;
 
-    public TokenAuthenticationInterceptor(CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider, AuthenticationConverter tokenAuthenticationConverter) {
+    public TokenAuthenticationInterceptor(UserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider, AuthenticationConverter tokenAuthenticationConverter) {
         this.customUserDetailsService = customUserDetailsService;
         this.jwtTokenProvider = jwtTokenProvider;
         this.tokenAuthenticationConverter = tokenAuthenticationConverter;

--- a/src/main/java/nextstep/auth/authentication/TokenAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/TokenAuthenticationInterceptor.java
@@ -7,42 +7,19 @@ import nextstep.auth.context.Authentication;
 import nextstep.auth.service.UserDetailsService;
 import nextstep.auth.token.JwtTokenProvider;
 import nextstep.auth.token.TokenResponse;
-import nextstep.member.domain.LoginMember;
 import org.springframework.http.MediaType;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
-import static nextstep.auth.authentication.AuthenticationException.PASSWORD_IS_INCORRECT;
-
 public class TokenAuthenticationInterceptor extends AuthenticationInterceptor {
 
-    private final UserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final AuthenticationConverter tokenAuthenticationConverter;
 
     public TokenAuthenticationInterceptor(UserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider, AuthenticationConverter tokenAuthenticationConverter) {
-        this.customUserDetailsService = customUserDetailsService;
+        super(customUserDetailsService, tokenAuthenticationConverter);
         this.jwtTokenProvider = jwtTokenProvider;
-        this.tokenAuthenticationConverter = tokenAuthenticationConverter;
-    }
-
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
-        AuthenticationToken authenticationToken = tokenAuthenticationConverter.convert(request);
-        Authentication authentication = authenticate(authenticationToken);
-
-        afterAuthentication(request, response, authentication);
-
-        return false;
-    }
-
-    public Authentication authenticate(AuthenticationToken authenticationToken) {
-        LoginMember principal = customUserDetailsService.loadUserByUsername(authenticationToken.getPrincipal());
-        checkCredential(principal, authenticationToken.getCredentials());
-        return new Authentication(principal);
     }
 
     @Override
@@ -64,12 +41,4 @@ public class TokenAuthenticationInterceptor extends AuthenticationInterceptor {
         return new TokenResponse(jwtTokenProvider.createToken(payload));
     }
 
-    private void checkCredential(LoginMember principal, String credentials) {
-        if (principal == null) {
-            throw new AuthenticationException(NOT_FOUND_EMAIL);
-        }
-        if (!principal.checkPassword(credentials)) {
-            throw new AuthenticationException(PASSWORD_IS_INCORRECT);
-        }
-    }
 }

--- a/src/main/java/nextstep/auth/authentication/convert/AuthenticationConverter.java
+++ b/src/main/java/nextstep/auth/authentication/convert/AuthenticationConverter.java
@@ -1,0 +1,10 @@
+package nextstep.auth.authentication.convert;
+
+import nextstep.auth.authentication.AuthenticationToken;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public interface AuthenticationConverter {
+	AuthenticationToken convert(HttpServletRequest request) throws IOException;
+}

--- a/src/main/java/nextstep/auth/authentication/convert/SessionAuthenticationConverter.java
+++ b/src/main/java/nextstep/auth/authentication/convert/SessionAuthenticationConverter.java
@@ -1,0 +1,22 @@
+package nextstep.auth.authentication.convert;
+
+import nextstep.auth.authentication.AuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+@Component
+public class SessionAuthenticationConverter implements AuthenticationConverter {
+	public static final String USERNAME_FIELD = "username";
+	public static final String PASSWORD_FIELD = "password";
+
+	@Override
+	public AuthenticationToken convert(HttpServletRequest request) {
+		Map<String, String[]> paramMap = request.getParameterMap();
+		String principal = paramMap.get(USERNAME_FIELD)[0];
+		String credentials = paramMap.get(PASSWORD_FIELD)[0];
+
+		return new AuthenticationToken(principal, credentials);
+	}
+}

--- a/src/main/java/nextstep/auth/authentication/convert/TokenAuthenticationConverter.java
+++ b/src/main/java/nextstep/auth/authentication/convert/TokenAuthenticationConverter.java
@@ -1,0 +1,26 @@
+package nextstep.auth.authentication.convert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.auth.authentication.AuthenticationToken;
+import nextstep.auth.token.TokenRequest;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@Component
+public class TokenAuthenticationConverter implements AuthenticationConverter {
+
+	@Override
+	public AuthenticationToken convert(HttpServletRequest request) throws IOException {
+		TokenRequest tokenRequest = readTokenRequest(request);
+		String principal = tokenRequest.getEmail();
+		String credentials = tokenRequest.getPassword();
+
+		return new AuthenticationToken(principal, credentials);
+	}
+
+	private TokenRequest readTokenRequest(HttpServletRequest request) throws IOException {
+		return new ObjectMapper().readValue(request.getInputStream(), TokenRequest.class);
+	}
+}

--- a/src/main/java/nextstep/auth/authorization/SecurityContextInterceptor.java
+++ b/src/main/java/nextstep/auth/authorization/SecurityContextInterceptor.java
@@ -1,0 +1,15 @@
+package nextstep.auth.authorization;
+
+import nextstep.auth.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public abstract class SecurityContextInterceptor implements HandlerInterceptor {
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+		SecurityContextHolder.clearContext();
+	}
+}

--- a/src/main/java/nextstep/auth/authorization/SessionSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/auth/authorization/SessionSecurityContextPersistenceInterceptor.java
@@ -2,14 +2,13 @@ package nextstep.auth.authorization;
 
 import nextstep.auth.context.SecurityContext;
 import nextstep.auth.context.SecurityContextHolder;
-import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static nextstep.auth.context.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
-public class SessionSecurityContextPersistenceInterceptor implements HandlerInterceptor {
+public class SessionSecurityContextPersistenceInterceptor extends SecurityContextInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         if (SecurityContextHolder.getContext().getAuthentication() != null) {
@@ -21,10 +20,5 @@ public class SessionSecurityContextPersistenceInterceptor implements HandlerInte
             SecurityContextHolder.setContext(securityContext);
         }
         return true;
-    }
-
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/nextstep/auth/domain/AuthenticatedMember.java
+++ b/src/main/java/nextstep/auth/domain/AuthenticatedMember.java
@@ -1,0 +1,5 @@
+package nextstep.auth.domain;
+
+public interface AuthenticatedMember {
+	boolean checkPassword(String credentials);
+}

--- a/src/main/java/nextstep/auth/service/UserDetailsService.java
+++ b/src/main/java/nextstep/auth/service/UserDetailsService.java
@@ -1,0 +1,8 @@
+package nextstep.auth.service;
+
+import nextstep.member.domain.LoginMember;
+
+public interface UserDetailsService {
+
+	LoginMember loadUserByUsername(String email);
+}

--- a/src/main/java/nextstep/auth/service/UserDetailsService.java
+++ b/src/main/java/nextstep/auth/service/UserDetailsService.java
@@ -1,8 +1,8 @@
 package nextstep.auth.service;
 
-import nextstep.member.domain.LoginMember;
+import nextstep.auth.domain.AuthenticatedMember;
 
 public interface UserDetailsService {
 
-	LoginMember loadUserByUsername(String email);
+	AuthenticatedMember loadUserByUsername(String email);
 }

--- a/src/main/java/nextstep/auth/token/JwtTokenProperties.java
+++ b/src/main/java/nextstep/auth/token/JwtTokenProperties.java
@@ -1,0 +1,29 @@
+package nextstep.auth.token;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProperties {
+
+	@Value("${security.jwt.token.secret-key}")
+	private String secretKey;
+	@Value("${security.jwt.token.expire-length}")
+	private long validityInMilliseconds;
+
+	private JwtTokenProperties() {
+	}
+
+	public JwtTokenProperties(String secretKey, long validityInMilliseconds) {
+		this.secretKey = secretKey;
+		this.validityInMilliseconds = validityInMilliseconds;
+	}
+
+	public String getSecretKey() {
+		return secretKey;
+	}
+
+	public long getValidityInMilliseconds() {
+		return validityInMilliseconds;
+	}
+}

--- a/src/main/java/nextstep/auth/token/JwtTokenProvider.java
+++ b/src/main/java/nextstep/auth/token/JwtTokenProvider.java
@@ -1,38 +1,45 @@
 package nextstep.auth.token;
 
 import io.jsonwebtoken.*;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
-    @Value("${security.jwt.token.secret-key}")
-    private String secretKey;
-    @Value("${security.jwt.token.expire-length}")
-    private long validityInMilliseconds;
+
+    private final JwtTokenProperties jwtTokenProperties;
+
+    public JwtTokenProvider(JwtTokenProperties jwtTokenProperties) {
+        this.jwtTokenProperties = jwtTokenProperties;
+    }
 
     public String createToken(String payload) {
         Claims claims = Jwts.claims().setSubject(payload);
         Date now = new Date();
-        Date validity = new Date(now.getTime() + validityInMilliseconds);
+        Date validity = new Date(now.getTime() + jwtTokenProperties.getValidityInMilliseconds());
 
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(validity)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProperties.getSecretKey())
                 .compact();
     }
 
     public String getPayload(String token) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+        return Jwts.parser()
+                .setSigningKey(jwtTokenProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
     }
 
     public boolean validateToken(String token) {
         try {
-            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            Jws<Claims> claims = Jwts.parser()
+                    .setSigningKey(jwtTokenProperties.getSecretKey())
+                    .parseClaimsJws(token);
 
             return !claims.getBody().getExpiration().before(new Date());
         } catch (JwtException | IllegalArgumentException e) {

--- a/src/main/java/nextstep/member/application/CustomUserDetailsService.java
+++ b/src/main/java/nextstep/member/application/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package nextstep.member.application;
 
 import nextstep.auth.authentication.AuthenticationException;
+import nextstep.auth.service.UserDetailsService;
 import nextstep.member.domain.LoginMember;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
@@ -9,13 +10,14 @@ import org.springframework.stereotype.Service;
 import static nextstep.auth.authentication.AuthenticationException.NOT_FOUND_EMAIL;
 
 @Service
-public class CustomUserDetailsService {
+public class CustomUserDetailsService implements UserDetailsService {
     private MemberRepository memberRepository;
 
     public CustomUserDetailsService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 
+    @Override
     public LoginMember loadUserByUsername(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthenticationException(NOT_FOUND_EMAIL));

--- a/src/main/java/nextstep/member/domain/LoginMember.java
+++ b/src/main/java/nextstep/member/domain/LoginMember.java
@@ -7,6 +7,9 @@ public class LoginMember {
     private String password;
     private Integer age;
 
+    private LoginMember() {
+    }
+
     public static LoginMember of(Member member) {
         return new LoginMember(member.getId(), member.getEmail(), member.getPassword(), member.getAge());
     }

--- a/src/main/java/nextstep/member/domain/LoginMember.java
+++ b/src/main/java/nextstep/member/domain/LoginMember.java
@@ -1,7 +1,9 @@
 package nextstep.member.domain;
 
 
-public class LoginMember {
+import nextstep.auth.domain.AuthenticatedMember;
+
+public class LoginMember implements AuthenticatedMember {
     private Long id;
     private String email;
     private String password;

--- a/src/test/java/nextstep/auth/authentication/SessionAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authentication/SessionAuthenticationInterceptorTest.java
@@ -3,8 +3,8 @@ package nextstep.auth.authentication;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authentication.convert.SessionAuthenticationConverter;
 import nextstep.auth.context.Authentication;
+import nextstep.auth.domain.AuthenticatedMember;
 import nextstep.auth.service.UserDetailsService;
-import nextstep.member.domain.LoginMember;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ class SessionAuthenticationInterceptorTest {
 		// given
 		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
 		when(userDetailsService.loadUserByUsername(anyString()))
-				.thenReturn(getMockLoginMember());
+				.thenReturn(new MockLoginMember());
 		// when
 		sessionAuthenticationInterceptor.preHandle(createMockRequest(), mockResponse, new Object());
 
@@ -58,7 +58,7 @@ class SessionAuthenticationInterceptorTest {
 	@Test
 	void authenticate() {
 		// given
-		LoginMember mockLoginMember = getMockLoginMember();
+		AuthenticatedMember mockLoginMember = new MockLoginMember();
 		when(userDetailsService.loadUserByUsername(anyString()))
 				.thenReturn(mockLoginMember);
 
@@ -67,13 +67,16 @@ class SessionAuthenticationInterceptorTest {
 		Authentication authenticate = sessionAuthenticationInterceptor.authenticate(authenticationToken);
 
 		// then
-		LoginMember principal = (LoginMember) authenticate.getPrincipal();
-		assertThat(principal.getEmail()).isEqualTo(mockLoginMember.getEmail());
-		assertThat(principal.getPassword()).isEqualTo(mockLoginMember.getPassword());
+		AuthenticatedMember principal = (AuthenticatedMember) authenticate.getPrincipal();
 	}
 
-	private LoginMember getMockLoginMember() {
-		return new LoginMember(0L, EMAIL, PASSWORD, 0);
+	static class MockLoginMember implements AuthenticatedMember {
+
+		@Override
+		public boolean checkPassword(String credentials) {
+			return true;
+		}
+
 	}
 
 	private HttpServletRequest createMockRequest() {

--- a/src/test/java/nextstep/auth/authentication/SessionAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authentication/SessionAuthenticationInterceptorTest.java
@@ -1,7 +1,5 @@
-package nextstep.subway.unit;
+package nextstep.auth.authentication;
 
-import nextstep.auth.authentication.AuthenticationToken;
-import nextstep.auth.authentication.SessionAuthenticationInterceptor;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authentication.convert.SessionAuthenticationConverter;
 import nextstep.auth.context.Authentication;

--- a/src/test/java/nextstep/auth/authentication/SessionAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authentication/SessionAuthenticationInterceptorTest.java
@@ -3,7 +3,7 @@ package nextstep.auth.authentication;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authentication.convert.SessionAuthenticationConverter;
 import nextstep.auth.context.Authentication;
-import nextstep.member.application.CustomUserDetailsService;
+import nextstep.auth.service.UserDetailsService;
 import nextstep.member.domain.LoginMember;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +34,7 @@ class SessionAuthenticationInterceptorTest {
 	AuthenticationConverter sessionAuthenticationConverter;
 
 	@Mock
-	CustomUserDetailsService userDetailsService;
+	UserDetailsService userDetailsService;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/nextstep/auth/authentication/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authentication/TokenAuthenticationInterceptorTest.java
@@ -1,9 +1,6 @@
-package nextstep.subway.unit;
+package nextstep.auth.authentication;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nextstep.auth.authentication.AuthenticationException;
-import nextstep.auth.authentication.AuthenticationToken;
-import nextstep.auth.authentication.TokenAuthenticationInterceptor;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authentication.convert.TokenAuthenticationConverter;
 import nextstep.auth.context.Authentication;

--- a/src/test/java/nextstep/auth/authentication/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authentication/TokenAuthenticationInterceptorTest.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.auth.authentication.convert.AuthenticationConverter;
 import nextstep.auth.authentication.convert.TokenAuthenticationConverter;
 import nextstep.auth.context.Authentication;
+import nextstep.auth.service.UserDetailsService;
 import nextstep.auth.token.JwtTokenProvider;
 import nextstep.auth.token.TokenRequest;
 import nextstep.auth.token.TokenResponse;
-import nextstep.member.application.CustomUserDetailsService;
 import nextstep.member.domain.LoginMember;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +36,7 @@ class TokenAuthenticationInterceptorTest {
     TokenAuthenticationInterceptor tokenAuthenticationInterceptor;
 
     @Mock
-    CustomUserDetailsService userDetailsService;
+    UserDetailsService userDetailsService;
 
     @Mock
     JwtTokenProvider jwtTokenProvider;

--- a/src/test/java/nextstep/auth/authentication/convert/SessionAuthenticationConverterTest.java
+++ b/src/test/java/nextstep/auth/authentication/convert/SessionAuthenticationConverterTest.java
@@ -1,0 +1,41 @@
+package nextstep.auth.authentication.convert;
+
+import nextstep.auth.authentication.AuthenticationToken;
+import nextstep.auth.authentication.SessionAuthenticationInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Session 기반 인증 토큰 변환 테스트")
+class SessionAuthenticationConverterTest {
+
+	private static final String EMAIL = "email@email.com";
+	private static final String PASSWORD = "password";
+
+	AuthenticationConverter sessionAuthenticationConverter;
+
+	@BeforeEach
+	void setUp() {
+		sessionAuthenticationConverter = new SessionAuthenticationConverter();
+	}
+
+	@Test
+	void convert() throws IOException {
+		// given
+		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+		mockHttpServletRequest.addParameter(SessionAuthenticationInterceptor.USERNAME_FIELD, EMAIL);
+		mockHttpServletRequest.addParameter(SessionAuthenticationInterceptor.PASSWORD_FIELD, PASSWORD);
+
+		// when
+		AuthenticationToken authenticationToken = sessionAuthenticationConverter.convert(mockHttpServletRequest);
+
+		// then
+		assertThat(authenticationToken.getPrincipal()).isEqualTo(EMAIL);
+		assertThat(authenticationToken.getCredentials()).isEqualTo(PASSWORD);
+	}
+}

--- a/src/test/java/nextstep/auth/authentication/convert/TokenAuthenticationConverterTest.java
+++ b/src/test/java/nextstep/auth/authentication/convert/TokenAuthenticationConverterTest.java
@@ -1,0 +1,45 @@
+package nextstep.auth.authentication.convert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.auth.authentication.AuthenticationToken;
+import nextstep.auth.token.TokenRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Token 기반 인증 토큰 변환 테스트")
+class TokenAuthenticationConverterTest {
+
+	private static final String EMAIL = "email@email.com";
+	private static final String PASSWORD = "password";
+
+	AuthenticationConverter tokenAuthenticationConverter;
+
+	@BeforeEach
+	void setUp() {
+		tokenAuthenticationConverter = new TokenAuthenticationConverter();
+	}
+
+	@Test
+	void convert() throws IOException {
+		// when
+		AuthenticationToken authenticationToken = tokenAuthenticationConverter.convert(createMockRequest());
+
+		// then
+		assertThat(authenticationToken.getPrincipal()).isEqualTo(EMAIL);
+		assertThat(authenticationToken.getCredentials()).isEqualTo(PASSWORD);
+	}
+
+	private MockHttpServletRequest createMockRequest() throws IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		TokenRequest tokenRequest = new TokenRequest(EMAIL, PASSWORD);
+		request.setContent(new ObjectMapper().writeValueAsString(tokenRequest).getBytes());
+		return request;
+	}
+
+}

--- a/src/test/java/nextstep/auth/authorization/SessionSecurityContextPersistenceInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authorization/SessionSecurityContextPersistenceInterceptorTest.java
@@ -1,0 +1,58 @@
+package nextstep.auth.authorization;
+
+import nextstep.auth.context.Authentication;
+import nextstep.auth.context.SecurityContext;
+import nextstep.auth.context.SecurityContextHolder;
+import nextstep.member.domain.LoginMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static nextstep.auth.context.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DisplayName("Token 기반 Authorization Interceptor 테스트")
+class SessionSecurityContextPersistenceInterceptorTest {
+
+	private static final String EMAIL = "email@email.com";
+	private static final String PASSWORD = "password";
+
+	SecurityContextInterceptor sessionSecurityContextInterceptor;
+
+	@BeforeEach
+	void setUp() {
+		sessionSecurityContextInterceptor = new SessionSecurityContextPersistenceInterceptor();
+	}
+
+	@Test
+	void preHandle() throws Exception {
+		// given
+		SecurityContext securityContext = new SecurityContext(new Authentication(createMockLoginMember()));
+
+		// when
+		sessionSecurityContextInterceptor.preHandle(createMockHttpServletRequest(securityContext), new MockHttpServletResponse(), new Object());
+
+		// then
+		LoginMember principal = (LoginMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		assertThat(principal.getEmail()).isEqualTo(EMAIL);
+		assertThat(principal.getPassword()).isEqualTo(PASSWORD);
+	}
+
+	private LoginMember createMockLoginMember() {
+		return new LoginMember(0L, EMAIL, PASSWORD, 0);
+	}
+
+	private HttpServletRequest createMockHttpServletRequest(SecurityContext securityContext) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(SPRING_SECURITY_CONTEXT_KEY, securityContext);
+		request.setSession(session);
+		return request;
+
+	}
+}

--- a/src/test/java/nextstep/auth/authorization/TokenSecurityContextPersistenceInterceptorTest.java
+++ b/src/test/java/nextstep/auth/authorization/TokenSecurityContextPersistenceInterceptorTest.java
@@ -1,0 +1,64 @@
+package nextstep.auth.authorization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.auth.context.SecurityContextHolder;
+import nextstep.auth.token.JwtTokenProperties;
+import nextstep.auth.token.JwtTokenProvider;
+import nextstep.member.domain.LoginMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DisplayName("Token 기반 Authorization Interceptor 테스트")
+class TokenSecurityContextPersistenceInterceptorTest {
+
+	private static final String EMAIL = "email@email.com";
+	private static final String PASSWORD = "password";
+
+	JwtTokenProperties fakeJwtTokenProperties = new JwtTokenProperties("secret", 10_000L);
+
+	SecurityContextInterceptor tokenSecurityContextPersistenceInterceptor;
+	JwtTokenProvider jwtTokenProvider;
+
+	@BeforeEach
+	void setUp() {
+		jwtTokenProvider = new JwtTokenProvider(fakeJwtTokenProperties);
+		tokenSecurityContextPersistenceInterceptor = new TokenSecurityContextPersistenceInterceptor(jwtTokenProvider);
+	}
+
+	@Test
+	void preHandle() throws Exception {
+		// when
+		tokenSecurityContextPersistenceInterceptor.preHandle(getMockHttpServletRequest(), new MockHttpServletResponse(), new Object());
+
+		// then
+		LoginMember principal = (LoginMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+		assertThat(principal.getEmail()).isEqualTo(EMAIL);
+		assertThat(principal.getPassword()).isEqualTo(PASSWORD);
+	}
+
+	private HttpServletRequest getMockHttpServletRequest() throws JsonProcessingException {
+		String TOKEN = createJwtToken();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(AuthorizationExtractor.AUTHORIZATION, "bearer " + TOKEN);
+		return request;
+	}
+
+	private LoginMember getMockLoginMember() {
+		return new LoginMember(0L, EMAIL, PASSWORD, 0);
+	}
+
+	private String createJwtToken() throws JsonProcessingException {
+		String payload = new ObjectMapper().writeValueAsString(getMockLoginMember());
+		return jwtTokenProvider.createToken(payload);
+	}
+
+}

--- a/src/test/java/nextstep/subway/unit/SessionAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/unit/SessionAuthenticationInterceptorTest.java
@@ -1,0 +1,88 @@
+package nextstep.subway.unit;
+
+import nextstep.auth.authentication.AuthenticationToken;
+import nextstep.auth.authentication.SessionAuthenticationInterceptor;
+import nextstep.auth.authentication.convert.AuthenticationConverter;
+import nextstep.auth.authentication.convert.SessionAuthenticationConverter;
+import nextstep.auth.context.Authentication;
+import nextstep.member.application.CustomUserDetailsService;
+import nextstep.member.domain.LoginMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("토큰 인증 기능 단위 테스트")
+class SessionAuthenticationInterceptorTest {
+
+	private static final String EMAIL = "email@email.com";
+	private static final String PASSWORD = "password";
+
+	SessionAuthenticationInterceptor sessionAuthenticationInterceptor;
+
+	AuthenticationConverter sessionAuthenticationConverter;
+
+	@Mock
+	CustomUserDetailsService userDetailsService;
+
+	@BeforeEach
+	void setUp() {
+		sessionAuthenticationConverter = new SessionAuthenticationConverter();
+		sessionAuthenticationInterceptor = new SessionAuthenticationInterceptor(userDetailsService, sessionAuthenticationConverter);
+	}
+
+	@Test
+	void preHandle() throws IOException {
+		// given
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+		when(userDetailsService.loadUserByUsername(anyString()))
+				.thenReturn(getMockLoginMember());
+		// when
+		sessionAuthenticationInterceptor.preHandle(createMockRequest(), mockResponse, new Object());
+
+		// then
+		assertThat(mockResponse.getStatus()).isEqualTo(HttpStatus.OK.value());
+	}
+
+	@Test
+	void authenticate() {
+		// given
+		LoginMember mockLoginMember = getMockLoginMember();
+		when(userDetailsService.loadUserByUsername(anyString()))
+				.thenReturn(mockLoginMember);
+
+		// when
+		AuthenticationToken authenticationToken = new AuthenticationToken(EMAIL, PASSWORD);
+		Authentication authenticate = sessionAuthenticationInterceptor.authenticate(authenticationToken);
+
+		// then
+		LoginMember principal = (LoginMember) authenticate.getPrincipal();
+		assertThat(principal.getEmail()).isEqualTo(mockLoginMember.getEmail());
+		assertThat(principal.getPassword()).isEqualTo(mockLoginMember.getPassword());
+	}
+
+	private LoginMember getMockLoginMember() {
+		return new LoginMember(0L, EMAIL, PASSWORD, 0);
+	}
+
+	private HttpServletRequest createMockRequest() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(SessionAuthenticationInterceptor.USERNAME_FIELD, EMAIL);
+		request.addParameter(SessionAuthenticationInterceptor.PASSWORD_FIELD, PASSWORD);
+		return request;
+	}
+
+}


### PR DESCRIPTION
안녕하세요. 이슬님!
평소에 리팩토링시 기존 코드를 건드리는 방식으로 했었어요.
이번 단계를 작업 하면서 지금까지 이런 잘못된 버릇을 개선할 수 있는 좋은 경험이었습니다!

아래는 제가 구현한 사항입니다. README.md 에 작성한 내용과 동일합니다.

### 1. 1,2단계에서 구현한 인증 로직에 대한 리팩터링
- AuthenticationConverter 추상화
  - AuthenticationConverter 인터페이스 생성
  - SessionAuthenticationConverter 와 TokenAuthenticationConverter 테스트 작성 및 구현
  - 기존 코드 대체
  - 전체 테스트 수행 후 실패 테스트 확인
  - 기존 코드 제거
- AuthenticationInterceptor 추상화
  - AuthenticationInterceptor 인터페이스 생성
  - 기존 코드 및 관련 테스트는 그대로 둠(SessionAuthenticationInterceptor, TokenAuthenticationInterceptor)
  - TokenAuthenticationInterceptor2 와 SessionAuthenticationInterceptor2 테스트 작성 및 구현
  - 기존 코드 대체
  - 전체 테스트 수행 후 실패 테스트 확인
  - 기존 코드 제거
- auth 패키지와 member 패키지의 양방향 의존 제거
  - UserDetailsService 인터페이스 생성
  - CustomUserDetailService 가 UserDetailsService 를 구현하도록 수정
  - 전체 테스트 수행 후 실패 테스트 확인
- SecurityContextInterceptor 추상화
  - SecurityContextInterceptor 인터페이스 생성
  - 기존 코드 및 관련 테스트는 그대로 둠(SessionSecurityContextPersistenceInterceptor, TokenSecurityContextPersistenceInterceptor)
  - SessionSecurityContextPersistenceInterceptor2, TokenSecurityContextPersistenceInterceptor2 테스트 작성 및 구현
  - 기존 코드 대체
  - 전체 테스트 수행 후 실패 테스트 확인
  - 기존 코드 제거

### 2. 내 정보 수정 / 삭제 기능을 처리하는 기능 구현
- Controller에서 @ㅐ너테이션을 활용하여 Login 정보에 접근