### PR TITLE
🚀 3단계 - 즐겨찾기 기능 구현

### DIFF
--- a/src/main/java/nextstep/auth/authentication/AbstractAuthenticationInterceptor.java
+++ b/src/main/java/nextstep/auth/authentication/AbstractAuthenticationInterceptor.java
@@ -24,7 +24,7 @@ public abstract class AbstractAuthenticationInterceptor implements HandlerInterc
         return false;
     }
 
-    public Authentication authenticate(AuthenticationToken authenticationToken) {
+    private Authentication authenticate(AuthenticationToken authenticationToken) {
         String principal = authenticationToken.getPrincipal();
         UserDetails userDetails = userDetailsService.loadUserByUsername(principal);
         checkAuthentication(userDetails, authenticationToken);

--- a/src/main/java/nextstep/auth/authorization/AbstractSecurityContextInterceptor.java
+++ b/src/main/java/nextstep/auth/authorization/AbstractSecurityContextInterceptor.java
@@ -1,0 +1,31 @@
+package nextstep.auth.authorization;
+
+import nextstep.auth.context.SecurityContext;
+import nextstep.auth.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public abstract class AbstractSecurityContextInterceptor implements HandlerInterceptor {
+
+    protected abstract SecurityContext extractSecurityContext(HttpServletRequest request);
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            return true;
+        }
+
+        SecurityContext securityContext = extractSecurityContext(request);
+        if (securityContext != null) {
+            SecurityContextHolder.setContext(securityContext);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/nextstep/auth/authorization/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/auth/authorization/AuthenticationPrincipalArgumentResolver.java
@@ -1,5 +1,6 @@
 package nextstep.auth.authorization;
 
+import nextstep.auth.authentication.AuthenticationException;
 import nextstep.auth.context.Authentication;
 import nextstep.auth.context.SecurityContextHolder;
 import org.springframework.core.MethodParameter;
@@ -10,6 +11,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
@@ -20,6 +22,9 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (Objects.isNull(authentication)) {
+            throw new AuthenticationException();
+        }
         if (authentication.getPrincipal() instanceof Map) {
             return extractPrincipal(parameter, authentication);
         }

--- a/src/main/java/nextstep/auth/authorization/SessionSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/auth/authorization/SessionSecurityContextPersistenceInterceptor.java
@@ -1,30 +1,15 @@
 package nextstep.auth.authorization;
 
 import nextstep.auth.context.SecurityContext;
-import nextstep.auth.context.SecurityContextHolder;
-import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import static nextstep.auth.context.SecurityContextHolder.SPRING_SECURITY_CONTEXT_KEY;
 
-public class SessionSecurityContextPersistenceInterceptor implements HandlerInterceptor {
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        if (SecurityContextHolder.getContext().getAuthentication() != null) {
-            return true;
-        }
-
-        SecurityContext securityContext = (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
-        if (securityContext != null) {
-            SecurityContextHolder.setContext(securityContext);
-        }
-        return true;
-    }
+public class SessionSecurityContextPersistenceInterceptor extends AbstractSecurityContextInterceptor {
 
     @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        SecurityContextHolder.clearContext();
+    protected SecurityContext extractSecurityContext(HttpServletRequest request) {
+        return (SecurityContext) request.getSession().getAttribute(SPRING_SECURITY_CONTEXT_KEY);
     }
 }

--- a/src/main/java/nextstep/auth/authorization/TokenSecurityContextPersistenceInterceptor.java
+++ b/src/main/java/nextstep/auth/authorization/TokenSecurityContextPersistenceInterceptor.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.auth.context.Authentication;
 import nextstep.auth.context.SecurityContext;
-import nextstep.auth.context.SecurityContextHolder;
 import nextstep.auth.token.JwtTokenProvider;
-import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 
-public class TokenSecurityContextPersistenceInterceptor implements HandlerInterceptor {
+public class TokenSecurityContextPersistenceInterceptor extends AbstractSecurityContextInterceptor {
+
     private JwtTokenProvider jwtTokenProvider;
 
     public TokenSecurityContextPersistenceInterceptor(JwtTokenProvider jwtTokenProvider) {
@@ -20,21 +18,13 @@ public class TokenSecurityContextPersistenceInterceptor implements HandlerInterc
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if (SecurityContextHolder.getContext().getAuthentication() != null) {
-            return true;
-        }
-
+    protected SecurityContext extractSecurityContext(HttpServletRequest request) {
         String credentials = AuthorizationExtractor.extract(request, AuthorizationType.BEARER);
         if (!jwtTokenProvider.validateToken(credentials)) {
-            return true;
+            return null;
         }
 
-        SecurityContext securityContext = extractSecurityContext(credentials);
-        if (securityContext != null) {
-            SecurityContextHolder.setContext(securityContext);
-        }
-        return true;
+        return extractSecurityContext(credentials);
     }
 
     private SecurityContext extractSecurityContext(String credentials) {

--- a/src/main/java/nextstep/subway/applicaion/FavoriteService.java
+++ b/src/main/java/nextstep/subway/applicaion/FavoriteService.java
@@ -1,0 +1,41 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.FavoriteRequest;
+import nextstep.subway.applicaion.dto.FavoriteResponse;
+import nextstep.subway.domain.Favorite;
+import nextstep.subway.domain.FavoriteRepository;
+import nextstep.subway.domain.Station;
+import nextstep.subway.domain.StationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final StationRepository stationRepository;
+
+    public FavoriteService(final FavoriteRepository favoriteRepository, final StationRepository stationRepository) {
+        this.favoriteRepository = favoriteRepository;
+        this.stationRepository = stationRepository;
+    }
+
+    public FavoriteResponse saveFavorite(final Long memberId, final FavoriteRequest request) {
+        final Station source = stationRepository.findById(request.getSource()).orElseThrow(IllegalArgumentException::new);
+        final Station target = stationRepository.findById(request.getTarget()).orElseThrow(IllegalArgumentException::new);
+
+        return FavoriteResponse.of(favoriteRepository.save(new Favorite(memberId, source, target)));
+    }
+
+    public List<FavoriteResponse> findAllFavorites(final Long memberId) {
+        return favoriteRepository.findAllByMemberId(memberId).stream()
+                .map(FavoriteResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteFavoriteById(final Long id) {
+        favoriteRepository.deleteById(id);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/FavoriteService.java
+++ b/src/main/java/nextstep/subway/applicaion/FavoriteService.java
@@ -35,7 +35,10 @@ public class FavoriteService {
                 .collect(Collectors.toList());
     }
 
-    public void deleteFavoriteById(final Long id) {
+    public void deleteFavoriteById(Long memberId, final Long id) {
+        final Favorite favorite = favoriteRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        favorite.validateMember(memberId);
+
         favoriteRepository.deleteById(id);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/FavoriteRequest.java
@@ -1,0 +1,15 @@
+package nextstep.subway.applicaion.dto;
+
+public class FavoriteRequest {
+
+    private Long source;
+    private Long target;
+
+    public Long getSource() {
+        return source;
+    }
+
+    public Long getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/FavoriteResponse.java
@@ -8,7 +8,7 @@ public class FavoriteResponse {
     private StationResponse source;
     private StationResponse target;
 
-    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+    private FavoriteResponse(Long id, StationResponse source, StationResponse target) {
         this.id = id;
         this.source = source;
         this.target = target;

--- a/src/main/java/nextstep/subway/applicaion/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/FavoriteResponse.java
@@ -1,0 +1,36 @@
+package nextstep.subway.applicaion.dto;
+
+import nextstep.subway.domain.Favorite;
+
+public class FavoriteResponse {
+
+    private Long id;
+    private StationResponse source;
+    private StationResponse target;
+
+    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+        this.id = id;
+        this.source = source;
+        this.target = target;
+    }
+
+    public static FavoriteResponse of(final Favorite favorite) {
+        return new FavoriteResponse(
+                favorite.getId(),
+                StationResponse.of(favorite.getSource()),
+                StationResponse.of(favorite.getTarget())
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StationResponse getSource() {
+        return source;
+    }
+
+    public StationResponse getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/domain/Favorite.java
@@ -1,5 +1,7 @@
 package nextstep.subway.domain;
 
+import nextstep.auth.authentication.AuthenticationException;
+
 import javax.persistence.*;
 
 @Entity
@@ -24,6 +26,12 @@ public class Favorite extends BaseEntity {
         this.memberId = memberId;
         this.source = source;
         this.target = target;
+    }
+
+    public void validateMember(Long memberId) {
+        if (!this.memberId.equals(memberId)) {
+            throw new AuthenticationException();
+        }
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/domain/Favorite.java
@@ -1,0 +1,40 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class Favorite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "source_id")
+    private Station source;
+    @ManyToOne
+    @JoinColumn(name = "target_id")
+    private Station target;
+
+    public Favorite() {
+    }
+
+    public Favorite(final Long memberId, final Station source, final Station target) {
+        this.memberId = memberId;
+        this.source = source;
+        this.target = target;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Station getSource() {
+        return source;
+    }
+
+    public Station getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/domain/FavoriteRepository.java
@@ -1,0 +1,10 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    List<Favorite> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -38,7 +38,7 @@ public class FavoriteController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteFavorites(@AuthenticationPrincipal final LoginMember loginMember,
                                                 @PathVariable final Long id) {
-        favoriteService.deleteFavoriteById(id);
+        favoriteService.deleteFavoriteById(loginMember.getId(), id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -1,0 +1,44 @@
+package nextstep.subway.ui;
+
+import nextstep.auth.authorization.AuthenticationPrincipal;
+import nextstep.member.domain.LoginMember;
+import nextstep.subway.applicaion.FavoriteService;
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.FavoriteRequest;
+import nextstep.subway.applicaion.dto.FavoriteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    public FavoriteController(final FavoriteService favoriteService, final StationService stationService) {
+        this.favoriteService = favoriteService;
+    }
+
+    @PostMapping
+    public ResponseEntity<FavoriteResponse> createFavorite(@AuthenticationPrincipal final LoginMember loginMember,
+                                                           @RequestBody final FavoriteRequest favoriteRequest) {
+        final FavoriteResponse favorite = favoriteService.saveFavorite(loginMember.getId(), favoriteRequest);
+        return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).body(favorite);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FavoriteResponse>> showFavorites(@AuthenticationPrincipal final LoginMember loginMember) {
+        final List<FavoriteResponse> favorites = favoriteService.findAllFavorites(loginMember.getId());
+        return ResponseEntity.ok(favorites);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteFavorites(@AuthenticationPrincipal final LoginMember loginMember,
+                                                @PathVariable final Long id) {
+        favoriteService.deleteFavoriteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -61,4 +61,56 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청(accessToken, createResponse);
         즐겨찾기_삭제됨(deleteResponse);
     }
+
+    /**
+     * Given 다른 회원 생성 요청
+     * And 다른 회원 로그인 되어 있음
+     * When 즐겨찾기 생성을 요청
+     * Then 즐겨찾기 생성됨
+     * When 다른 회원으로 즐겨찾기 삭제 요청
+     * Then 권한 없음 오류 반환됨
+     */
+    @DisplayName("다른 회원의 즐겨찾기를 삭제한다.")
+    @Test
+    void deleteFavoriteOfOtherMember() {
+        // given
+        final String otherEmail = "otherEmail@email.com";
+        final String otherPassword = "otherPassword";
+        final int otherAge = 20;
+        회원_생성_요청(otherEmail, otherPassword, otherAge);
+        final String otherAccessToken = 로그인_되어_있음(otherEmail, otherPassword);
+
+        // when
+        ExtractableResponse<Response> createResponse = 즐겨찾기_생성_요청(accessToken, sourceId, targetId);
+        // then
+        즐겨찾기_생성됨(createResponse);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청(otherAccessToken, createResponse);
+        // then
+        권한_없음_오류_반환됨(deleteResponse);
+    }
+
+    /**
+     * When 로그인 없이 즐겨찾기 생성을 요청
+     * Then 권한 없음 오류 반환됨
+     * When 로그인 없이 즐겨찾기 목록 조회 요청
+     * Then 권한 없음 오류 반환됨
+     * When 즐겨찾기 생성을 요청
+     * And 로그인 없이 즐겨찾기 삭제 요청
+     * Then 권한 없음 오류 반환됨
+     */
+    @DisplayName("로그인 없이 즐겨찾기를 관리한다.")
+    @Test
+    void deleteFavoriteWithoutAccessToken() {
+        ExtractableResponse<Response> createResponse = 로그인_없이_즐겨찾기_생성_요청(sourceId, targetId);
+        권한_없음_오류_반환됨(createResponse);
+
+        ExtractableResponse<Response> showResponse = 로그인_없이_즐겨찾기_목록_조회_요청();
+        권한_없음_오류_반환됨(showResponse);
+
+        ExtractableResponse<Response> response = 즐겨찾기_생성_요청(accessToken, sourceId, targetId);
+        ExtractableResponse<Response> deleteResponse = 로그인_없이_즐겨찾기_삭제_요청(response);
+        권한_없음_오류_반환됨(deleteResponse);
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,64 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static nextstep.subway.acceptance.FavoriteSteps.*;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_생성_요청;
+import static nextstep.subway.acceptance.MemberSteps.로그인_되어_있음;
+import static nextstep.subway.acceptance.MemberSteps.회원_생성_요청;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+
+public class FavoriteAcceptanceTest extends AcceptanceTest {
+
+    private String accessToken;
+    private Long sourceId;
+    private Long targetId;
+
+    /**
+     * Given 지하철역 등록되어 있음
+     * And 지하철 노선 등록되어 있음
+     * And 지하철 노선에 지하철역 등록되어 있음
+     * And 회원 등록되어 있음
+     * And 로그인 되어있음
+     */
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        sourceId = 지하철역_생성_요청("교대역").jsonPath().getLong("id");
+        targetId = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        지하철_노선_생성_요청("2호선", "green", sourceId, targetId, 10);
+
+        final String EMAIL = "email@email.com";
+        final String PASSWORD = "password";
+        final int AGE = 20;
+        회원_생성_요청(EMAIL, PASSWORD, AGE);
+        accessToken = 로그인_되어_있음(EMAIL, PASSWORD);
+    }
+
+    /**
+     * When 즐겨찾기 생성을 요청
+     * Then 즐겨찾기 생성됨
+     * When 즐겨찾기 목록 조회 요청
+     * Then 즐겨찾기 목록 조회됨
+     * When 즐겨찾기 삭제 요청
+     * Then 즐겨찾기 삭제됨
+     */
+    @DisplayName("즐겨찾기를 관리한다.")
+    @Test
+    void manageFavorite() {
+        ExtractableResponse<Response> createResponse = 즐겨찾기_생성_요청(accessToken, sourceId, targetId);
+        즐겨찾기_생성됨(createResponse);
+
+        ExtractableResponse<Response> showResponse = 즐겨찾기_목록_조회_요청(accessToken);
+        즐겨찾기_목록_조회됨(showResponse);
+
+        ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청(accessToken, createResponse);
+        즐겨찾기_삭제됨(deleteResponse);
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -56,4 +56,34 @@ public class FavoriteSteps {
     public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> deleteResponse) {
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    public static void 권한_없음_오류_반환됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    public static ExtractableResponse<Response> 로그인_없이_즐겨찾기_생성_요청(Long sourceId, Long targetId) {
+        Map<String, String> params = new HashMap<>();
+        params.put("source", sourceId + "");
+        params.put("target", targetId + "");
+
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post(FAVORITES_PATH)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 로그인_없이_즐겨찾기_목록_조회_요청() {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(FAVORITES_PATH)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 로그인_없이_즐겨찾기_삭제_요청(ExtractableResponse<Response> createResponse) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete(createResponse.header(HttpHeaders.LOCATION))
+                .then().log().all().extract();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -1,0 +1,59 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FavoriteSteps {
+
+    private static final String FAVORITES_PATH = "/favorites";
+
+    public static ExtractableResponse<Response> 즐겨찾기_생성_요청(String accessToken, Long sourceId, Long targetId) {
+        Map<String, String> params = new HashMap<>();
+        params.put("source", sourceId + "");
+        params.put("target", targetId + "");
+
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post(FAVORITES_PATH)
+                .then().log().all().extract();
+    }
+
+    public static void 즐겨찾기_생성됨(ExtractableResponse<Response> createResponse) {
+        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_목록_조회_요청(String accessToken) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(FAVORITES_PATH)
+                .then().log().all().extract();
+    }
+
+    public static void 즐겨찾기_목록_조회됨(ExtractableResponse<Response> findResponse) {
+        assertThat(findResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_삭제_요청(String accessToken, ExtractableResponse<Response> createResponse) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete(createResponse.header(HttpHeaders.LOCATION))
+                .then().log().all().extract();
+    }
+
+    public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> deleteResponse) {
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -64,4 +64,16 @@ public class LineSteps {
                 .when().delete("/lines/{lineId}/sections?stationId={stationId}", lineId, stationId)
                 .then().log().all().extract();
     }
+
+    public static Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
+        Map<String, String> lineCreateParams;
+        lineCreateParams = new HashMap<>();
+        lineCreateParams.put("name", name);
+        lineCreateParams.put("color", color);
+        lineCreateParams.put("upStationId", upStation + "");
+        lineCreateParams.put("downStationId", downStation + "");
+        lineCreateParams.put("distance", distance + "");
+
+        return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -66,8 +66,7 @@ public class LineSteps {
     }
 
     public static Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
+        Map<String, String> lineCreateParams = new HashMap<>();
         lineCreateParams.put("name", name);
         lineCreateParams.put("color", color);
         lineCreateParams.put("upStationId", upStation + "");

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import java.util.HashMap;
 import java.util.Map;
 
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_생성_요청;
 import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,18 +65,6 @@ class PathAcceptanceTest extends AcceptanceTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/paths?source={sourceId}&target={targetId}", source, target)
                 .then().log().all().extract();
-    }
-
-    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", name);
-        lineCreateParams.put("color", color);
-        lineCreateParams.put("upStationId", upStation + "");
-        lineCreateParams.put("downStationId", downStation + "");
-        lineCreateParams.put("distance", distance + "");
-
-        return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
     }
 
     private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {

--- a/src/test/java/nextstep/subway/unit/FavoriteTest.java
+++ b/src/test/java/nextstep/subway/unit/FavoriteTest.java
@@ -1,0 +1,25 @@
+package nextstep.subway.unit;
+
+import nextstep.auth.authentication.AuthenticationException;
+import nextstep.subway.domain.Favorite;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class FavoriteTest {
+
+    @Test
+    void validateMember() {
+        // given
+        final Station source = new Station("강남역");
+        final Station target = new Station("역삼역");
+        final Long memberId = 1L;
+        final Long otherMemberId = 2L;
+        final Favorite favorite = new Favorite(memberId, source, target);
+
+        // when
+        // then
+        assertThatExceptionOfType(AuthenticationException.class).isThrownBy(() -> favorite.validateMember(otherMemberId));
+    }
+}

--- a/src/test/java/nextstep/subway/unit/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/nextstep/subway/unit/TokenAuthenticationInterceptorTest.java
@@ -71,15 +71,6 @@ class TokenAuthenticationInterceptorTest {
     }
 
     @Test
-    void authenticate() {
-        // when
-        Authentication authentication = interceptor.authenticate(new AuthenticationToken(EMAIL, PASSWORD));
-
-        // then
-        assertThat(authentication.getPrincipal()).isNotNull();
-    }
-
-    @Test
     void afterAuthentication() throws IOException {
         // when
         MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
# 요구사항
- [x] 즐겨 찾기 기능을 구현하기
- [x] 로그인이 필요한 API 요청 시 유효하지 않은 경우 401 응답 내려주기
---
안녕하세요, 승철 님.

지난 코드리뷰에서 [피드백](https://github.com/next-step/atdd-subway-favorite/pull/226#pullrequestreview-888002453) 주셨던 내용을 반영했습니다.

코멘트 남겨주셨던 내용에 대해서는 다음과 같은 이유로 있었습니다.

- [코멘트#1](https://github.com/next-step/atdd-subway-favorite/pull/226#discussion_r810588509) :

  해당 인스턴스는 직렬화 시 회원 정보에 대한 데이터가 포함되어야 했기 때문에,
  멤버 변수를 넣어주기 위해 익명 클래스로 초기화 해주었습니다.

- [코멘트#2](https://github.com/next-step/atdd-subway-favorite/pull/226#discussion_r810588702) :

  해당 메소드를 테스트 하기 위해 `public` 접근 제어자를 유지해 주었습니다.

또한, 3 단계 요구사항 구현을 진행했습니다.

마지막 리뷰 잘 부탁드립니다.

감사합니다. ^^7