### PR TITLE
Step1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     // jwt
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+    // guava
+    implementation("com.google.guava:guava:28.2-jre")
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.2.0'

--- a/src/main/java/nextstep/DataLoader.java
+++ b/src/main/java/nextstep/DataLoader.java
@@ -1,9 +1,20 @@
 package nextstep;
 
+import com.google.common.collect.Lists;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import nextstep.member.domain.RoleType;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DataLoader {
+    private MemberRepository memberRepository;
+
+    public DataLoader(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
     public void loadData() {
+        memberRepository.save(new Member("admin@email.com", "password", 36, Lists.newArrayList(RoleType.ROLE_ADMIN.name())));
     }
 }

--- a/src/main/java/nextstep/auth/authentication/BearerTokenAuthenticationFilter.java
+++ b/src/main/java/nextstep/auth/authentication/BearerTokenAuthenticationFilter.java
@@ -1,10 +1,13 @@
 package nextstep.auth.authentication;
 
+import nextstep.auth.context.Authentication;
+import nextstep.auth.context.SecurityContextHolder;
 import nextstep.auth.token.JwtTokenProvider;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 public class BearerTokenAuthenticationFilter implements HandlerInterceptor {
     private JwtTokenProvider jwtTokenProvider;
@@ -15,7 +18,24 @@ public class BearerTokenAuthenticationFilter implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        // TODO: 구현하세요.
-        return true;
+        try {
+            String authCredentials = AuthorizationExtractor.extract(request, AuthorizationType.BEARER);
+            AuthenticationToken token = new AuthenticationToken(authCredentials, authCredentials);
+
+            if (!jwtTokenProvider.validateToken(token.getPrincipal())) {
+                throw new AuthenticationException();
+            }
+
+            String principal = jwtTokenProvider.getPrincipal(token.getPrincipal());
+            List<String> roles = jwtTokenProvider.getRoles(token.getPrincipal());
+
+            Authentication authentication = new Authentication(principal, roles);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            return true;
+        } catch (Exception e) {
+            return true;
+        }
     }
 }

--- a/src/main/java/nextstep/auth/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/nextstep/auth/authentication/UsernamePasswordAuthenticationFilter.java
@@ -1,12 +1,19 @@
 package nextstep.auth.authentication;
 
+import nextstep.auth.context.Authentication;
+import nextstep.auth.context.SecurityContextHolder;
 import nextstep.member.application.LoginMemberService;
+import nextstep.member.domain.LoginMember;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
 
 public class UsernamePasswordAuthenticationFilter implements HandlerInterceptor {
+    public static final String USERNAME_FIELD = "username";
+    public static final String PASSWORD_FIELD = "password";
+
     private LoginMemberService loginMemberService;
 
     public UsernamePasswordAuthenticationFilter(LoginMemberService loginMemberService) {
@@ -15,7 +22,31 @@ public class UsernamePasswordAuthenticationFilter implements HandlerInterceptor 
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        // TODO: 구현하세요.
-        return true;
+        try {
+            Map<String, String[]> paramMap = request.getParameterMap();
+            String username = paramMap.get(USERNAME_FIELD)[0];
+            String password = paramMap.get(PASSWORD_FIELD)[0];
+
+            AuthenticationToken token = new AuthenticationToken(username, password);
+
+            String principal = token.getPrincipal();
+            LoginMember loginMember = loginMemberService.loadUserByUsername(principal);
+
+            if (loginMember == null) {
+                throw new AuthenticationException();
+            }
+
+            if (!loginMember.checkPassword(token.getCredentials())) {
+                throw new AuthenticationException();
+            }
+
+            Authentication authentication = new Authentication(loginMember.getEmail(), loginMember.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            return false;
+        } catch (Exception e) {
+            return true;
+        }
     }
 }

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,6 +1,8 @@
 package nextstep.subway.ui;
 
+import nextstep.auth.authentication.AuthenticationException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,5 +17,10 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Void> handleIllegalArgsException(IllegalArgumentException e) {
         return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<Void> handleAuthenticationException(AuthenticationException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,5 +1,6 @@
 package nextstep.subway.ui;
 
+import nextstep.auth.secured.Secured;
 import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
@@ -19,6 +20,7 @@ public class LineController {
         this.lineService = lineService;
     }
 
+    @Secured("ROLE_ADMIN")
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse line = lineService.saveLine(lineRequest);
@@ -37,24 +39,28 @@ public class LineController {
         return ResponseEntity.ok().body(lineResponse);
     }
 
+    @Secured("ROLE_ADMIN")
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
         lineService.updateLine(id, lineRequest);
         return ResponseEntity.ok().build();
     }
 
+    @Secured("ROLE_ADMIN")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> updateLine(@PathVariable Long id) {
         lineService.deleteLine(id);
         return ResponseEntity.noContent().build();
     }
 
+    @Secured("ROLE_ADMIN")
     @PostMapping("/{lineId}/sections")
     public ResponseEntity<Void> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
         lineService.addSection(lineId, sectionRequest);
         return ResponseEntity.ok().build();
     }
 
+    @Secured("ROLE_ADMIN")
     @DeleteMapping("/{lineId}/sections")
     public ResponseEntity<Void> deleteSection(@PathVariable Long lineId, @RequestParam Long stationId) {
         lineService.deleteSection(lineId, stationId);

--- a/src/main/java/nextstep/subway/ui/StationController.java
+++ b/src/main/java/nextstep/subway/ui/StationController.java
@@ -1,5 +1,6 @@
 package nextstep.subway.ui;
 
+import nextstep.auth.secured.Secured;
 import nextstep.subway.applicaion.StationService;
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
@@ -18,6 +19,7 @@ public class StationController {
         this.stationService = stationService;
     }
 
+    @Secured("ROLE_ADMIN")
     @PostMapping("/stations")
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
         StationResponse station = stationService.saveStation(stationRequest);
@@ -29,6 +31,7 @@ public class StationController {
         return ResponseEntity.ok().body(stationService.findAllStations());
     }
 
+    @Secured("ROLE_ADMIN")
     @DeleteMapping("/stations/{id}")
     public ResponseEntity<Void> deleteStation(@PathVariable Long id) {
         stationService.deleteStationById(id);

--- a/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
@@ -24,7 +24,7 @@ public class AcceptanceTest {
     @Autowired
     private DataLoader dataLoader;
 
-    private String 관리자;
+    String 관리자;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
@@ -1,6 +1,7 @@
 package nextstep.subway.acceptance;
 
 import io.restassured.RestAssured;
+import nextstep.DataLoader;
 import nextstep.subway.utils.DatabaseCleanup;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,15 +12,26 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
+    private static final String EMAIL = "admin@email.com";
+    private static final String PASSWORD = "password";
+
     @LocalServerPort
     int port;
 
     @Autowired
     private DatabaseCleanup databaseCleanup;
 
+    @Autowired
+    private DataLoader dataLoader;
+
+    private String 관리자;
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
         databaseCleanup.execute();
+        dataLoader.loadData();
+
+        관리자 = MemberSteps.로그인_되어_있음(EMAIL, PASSWORD);
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/AcceptanceTestSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/AcceptanceTestSteps.java
@@ -1,0 +1,17 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+public class AcceptanceTestSteps {
+    static RequestSpecification given() {
+        return RestAssured
+                .given().log().all();
+    }
+
+    static RequestSpecification given(String token) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(token);
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
@@ -1,9 +1,13 @@
 package nextstep.subway.acceptance;
 
+import io.restassured.RestAssured;
+import io.restassured.authentication.FormAuthConfig;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 import static nextstep.subway.acceptance.MemberSteps.*;
 
@@ -40,7 +44,13 @@ class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     private ExtractableResponse<Response> 폼_로그인_후_내_회원_정보_조회_요청(String email, String password) {
-        return null;
+        return RestAssured
+                .given().log().all()
+                .auth().form(email, password, new FormAuthConfig("/login/form", USERNAME_FIELD, PASSWORD_FIELD))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/members/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value()).extract();
     }
 
     private ExtractableResponse<Response> 베어러_인증으로_내_회원_정보_조회_요청(String accessToken) {

--- a/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
@@ -11,7 +11,7 @@ import static nextstep.subway.acceptance.MemberSteps.*;
 class AuthAcceptanceTest extends AcceptanceTest {
     private static final String EMAIL = "admin@email.com";
     private static final String PASSWORD = "password";
-    private static final Integer AGE = 20;
+    private static final Integer AGE = 36;
 
     @DisplayName("Basic Auth")
     @Test

--- a/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import static nextstep.subway.acceptance.MemberSteps.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthAcceptanceTest extends AcceptanceTest {
     private static final String EMAIL = "admin@email.com";
@@ -43,6 +43,18 @@ class AuthAcceptanceTest extends AcceptanceTest {
         회원_정보_조회됨(response, EMAIL, AGE);
     }
 
+    @DisplayName("Bearer Auth With Invalid Token")
+    @Test
+    void myInfoWithBearerAuthUsingInvalidToken() {
+        String accessToken = 로그인_되어_있음(EMAIL, PASSWORD) + 1;
+
+        ExtractableResponse<Response> response = 베어러_인증으로_내_회원_정보_조회_요청(accessToken);
+        System.out.println("====");
+        System.out.println(response.jsonPath().getString("."));
+//        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.jsonPath().getString("path")).isEqualTo("/members/me");
+    }
+
     private ExtractableResponse<Response> 폼_로그인_후_내_회원_정보_조회_요청(String email, String password) {
         return RestAssured
                 .given().log().all()
@@ -59,7 +71,6 @@ class AuthAcceptanceTest extends AcceptanceTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/members/me")
                 .then().log().all()
-                .statusCode(HttpStatus.OK.value())
                 .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
@@ -54,6 +54,12 @@ class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     private ExtractableResponse<Response> 베어러_인증으로_내_회원_정보_조회_요청(String accessToken) {
-        return null;
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/members/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,15 +1,10 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +19,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(관리자, "2호선", "green");
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -42,8 +37,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        지하철_노선_생성_요청("2호선", "green");
-        지하철_노선_생성_요청("3호선", "orange");
+        지하철_노선_생성_요청(관리자, "2호선", "green");
+        지하철_노선_생성_요청(관리자, "3호선", "orange");
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
@@ -62,7 +57,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청(관리자, "2호선", "green");
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
@@ -81,17 +76,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청(관리자, "2호선", "green");
 
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("color", "red");
-        RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put(createResponse.header("location"))
-                .then().log().all().extract();
+        지하철_노선_수정_요청(관리자, createResponse.header("location"));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
@@ -108,13 +96,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청(관리자, "2호선", "green");
 
         // when
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .when().delete(createResponse.header("location"))
-                .then().log().all().extract();
+        ExtractableResponse<Response> response = 지하철_노선_삭제_요청(관리자, createResponse.header("location"));
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -32,7 +32,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
 
         Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
-        신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+        신분당선 = 지하철_노선_생성_요청(관리자, lineCreateParams).jsonPath().getLong("id");
     }
 
     /**
@@ -44,7 +44,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void addLineSection() {
         // when
         Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(양재역, 정자역));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -61,7 +61,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void addLineSectionMiddle() {
         // when
         Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(강남역, 정자역));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -77,7 +77,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addSectionAlreadyIncluded() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역));
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(강남역, 양재역));
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -93,10 +93,10 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void removeLineSection() {
         // given
         Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(양재역, 정자역));
 
         // when
-        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+        지하철_노선에_지하철_구간_제거_요청(관리자, 신분당선, 정자역);
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -114,10 +114,10 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void removeLineSectionInMiddle() {
         // given
         Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(양재역, 정자역));
 
         // when
-        지하철_노선에_지하철_구간_제거_요청(신분당선, 양재역);
+        지하철_노선에_지하철_구간_제거_요청(관리자, 신분당선, 양재역);
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -28,8 +28,8 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     public void setUp() {
         super.setUp();
 
-        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
-        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+        강남역 = 지하철역_생성_요청(관리자, "강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
 
         Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
         신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
@@ -43,7 +43,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSection() {
         // when
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
 
         // then
@@ -60,7 +60,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSectionMiddle() {
         // when
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 정자역));
 
         // then
@@ -92,7 +92,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection() {
         // given
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
 
         // when
@@ -113,7 +113,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSectionInMiddle() {
         // given
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
 
         // when

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -8,13 +8,12 @@ import org.springframework.http.MediaType;
 import java.util.HashMap;
 import java.util.Map;
 
-public class LineSteps {
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
+public class LineSteps extends AcceptanceTestSteps {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String token, String name, String color) {
         Map<String, String> params = new HashMap<>();
         params.put("name", name);
         params.put("color", color);
-        return RestAssured
-                .given().log().all()
+        return given(token)
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/lines")
@@ -22,15 +21,13 @@ public class LineSteps {
     }
 
     public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
-        return RestAssured
-                .given().log().all()
+        return given()
                 .when().get("/lines")
                 .then().log().all().extract();
     }
 
     public static ExtractableResponse<Response> 지하철_노선_조회_요청(ExtractableResponse<Response> createResponse) {
-        return RestAssured
-                .given().log().all()
+        return given()
                 .when().get(createResponse.header("location"))
                 .then().log().all().extract();
     }
@@ -42,25 +39,42 @@ public class LineSteps {
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> params) {
-        return RestAssured
-                .given().log().all()
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String token, Map<String, String> params) {
+        return given(token)
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/lines")
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_생성_요청(Long lineId, Map<String, String> params) {
-        return RestAssured.given().log().all()
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(String token, String location) {
+        Map<String, String> params = new HashMap<>();
+        params.put("color", "red");
+        return given(token)
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put(location)
+                .then().log().all().extract();
+    }
+
+
+    public static ExtractableResponse<Response> 지하철_노선_삭제_요청(String token, String location) {
+        ExtractableResponse<Response> response = given(token)
+                .when().delete(location)
+                .then().log().all().extract();
+        return response;
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_생성_요청(String token, Long lineId, Map<String, String> params) {
+        return given(token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(params)
                 .when().post("/lines/{lineId}/sections", lineId)
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_제거_요청(Long lineId, Long stationId) {
-        return RestAssured.given().log().all()
+    public static ExtractableResponse<Response> 지하철_노선에_지하철_구간_제거_요청(String token, Long lineId, Long stationId) {
+        return given(token)
                 .when().delete("/lines/{lineId}/sections?stationId={stationId}", lineId, stationId)
                 .then().log().all().extract();
     }

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -36,10 +36,10 @@ class PathAcceptanceTest extends AcceptanceTest {
     public void setUp() {
         super.setUp();
 
-        교대역 = 지하철역_생성_요청("교대역").jsonPath().getLong("id");
-        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
-        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
-        남부터미널역 = 지하철역_생성_요청("남부터미널역").jsonPath().getLong("id");
+        교대역 = 지하철역_생성_요청(관리자, "교대역").jsonPath().getLong("id");
+        강남역 = 지하철역_생성_요청(관리자, "강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
+        남부터미널역 = 지하철역_생성_요청(관리자, "남부터미널역").jsonPath().getLong("id");
 
         이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10);
         신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10);

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -45,7 +45,7 @@ class PathAcceptanceTest extends AcceptanceTest {
         신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10);
         삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2);
 
-        지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역, 3));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 삼호선, createSectionCreateParams(남부터미널역, 양재역, 3));
     }
 
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
@@ -75,7 +75,7 @@ class PathAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("downStationId", downStation + "");
         lineCreateParams.put("distance", distance + "");
 
-        return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+        return LineSteps.지하철_노선_생성_요청(관리자, lineCreateParams).jsonPath().getLong("id");
     }
 
     private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -28,8 +28,8 @@ class SectionAcceptanceTest extends AcceptanceTest {
     public void setUp() {
         super.setUp();
 
-        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
-        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+        강남역 = 지하철역_생성_요청(관리자, "강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
 
         Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
         신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
@@ -43,7 +43,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSection() {
         // when
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
 
         // then
@@ -61,7 +61,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection() {
         // given
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
+        Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
         지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
 
         // when

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -32,7 +32,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
         양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
 
         Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
-        신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+        신분당선 = 지하철_노선_생성_요청(관리자, lineCreateParams).jsonPath().getLong("id");
     }
 
     /**
@@ -44,7 +44,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
     void addLineSection() {
         // when
         Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(양재역, 정자역));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -62,10 +62,10 @@ class SectionAcceptanceTest extends AcceptanceTest {
     void removeLineSection() {
         // given
         Long 정자역 = 지하철역_생성_요청(관리자, "정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 신분당선, createSectionCreateParams(양재역, 정자역));
 
         // when
-        지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
+        지하철_노선에_지하철_구간_제거_요청(관리자, 신분당선, 정자역);
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
+import static nextstep.subway.acceptance.StationSteps.지하철역_삭제_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +26,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStation() {
         // when
-        ExtractableResponse<Response> response = 지하철역_생성_요청("강남역");
+        ExtractableResponse<Response> response = 지하철역_생성_요청(관리자, "강남역");
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -48,8 +49,8 @@ public class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         // given
-        지하철역_생성_요청("강남역");
-        지하철역_생성_요청("역삼역");
+        지하철역_생성_요청(관리자, "강남역");
+        지하철역_생성_요청(관리자, "역삼역");
 
         // when
         ExtractableResponse<Response> stationResponse = RestAssured.given().log().all()
@@ -71,15 +72,10 @@ public class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철역_생성_요청("강남역");
+        ExtractableResponse<Response> createResponse = 지하철역_생성_요청(관리자, "강남역");
 
         // when
-        String location = createResponse.header("location");
-        RestAssured.given().log().all()
-                .when()
-                .delete(location)
-                .then().log().all()
-                .extract();
+        지하철역_삭제_요청(관리자, createResponse.header("location"));
 
         // then
         List<String> stationNames =

--- a/src/test/java/nextstep/subway/acceptance/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/StationSteps.java
@@ -1,6 +1,5 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
@@ -8,15 +7,22 @@ import org.springframework.http.MediaType;
 import java.util.HashMap;
 import java.util.Map;
 
-public class StationSteps {
-    public static ExtractableResponse<Response> 지하철역_생성_요청(String name) {
+public class StationSteps extends AcceptanceTestSteps {
+    public static ExtractableResponse<Response> 지하철역_생성_요청(String token, String name) {
         Map<String, String> params = new HashMap<>();
         params.put("name", name);
-        return RestAssured.given().log().all()
+        return given(token)
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철역_삭제_요청(String token, String location) {
+        return given(token)
+                .delete(location)
                 .then().log().all()
                 .extract();
     }


### PR DESCRIPTION
안녕하세요 리뷰어님
리뷰이 엄홍준이라고 합니다.
조부님 상을 당해 늦게 PR 드립니다.
강의를 몇 번 반복해 들었는데 이해가 잘 가지 않아 뼈대 코드와 다른 분의 코드를 참고하여 작성하였는데 몇 가지 질문 드리고 싶습니다(기록 용도로 남겨 놓는 것도 있으니 혹 답변이 어려우시더라도 괜찮습니다).
감사합니다.

- - -
**토큰이 유효하지 않은 경우 에러 응답이 오는지 확인**하는 것이 이번 요구사항 중 하나이고, AuthAcceptanceTest 클래스의 myInfoWithBearerAuthUsingInvalidToken 메소드를 통해 검증하려고 하였습니다. 이때 Interceptor의 예외 역시 ControllerAdvice로 처리할 수 있다고 생각하여 ControllerExceptionHandler에 다음을 추가했습니다.

```java
@ExceptionHandler(AuthenticationException.class)
public ResponseEntity<Void> handleAuthenticationException(AuthenticationException e) {
	return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
}
```

그리고 BearerTokenAuthenticationFilter 클래스의 preHandle 메소드를 다음과 같이 작성하였습니다.

```java
String authCredentials = AuthorizationExtractor.extract(request, AuthorizationType.BEARER);
AuthenticationToken token = new AuthenticationToken(authCredentials, authCredentials);

if (!jwtTokenProvider.validateToken(token.getPrincipal())) {
	throw new AuthenticationException();
}

String principal = jwtTokenProvider.getPrincipal(token.getPrincipal());
List<String> roles = jwtTokenProvider.getRoles(token.getPrincipal());

Authentication authentication = new Authentication(principal, roles);

SecurityContextHolder.getContext().setAuthentication(authentication);

return true;
```

즉, try-catch문 없이 작성하여 AuthenticationException 발생 시 다음과 같이 검증 가능했습니다.

```java
@DisplayName("Bearer Auth With Invalid Token")
@Test
void myInfoWithBearerAuthUsingInvalidToken() {
	String invalidAccessToken = 로그인_되어_있음(EMAIL, PASSWORD) + 1;
	ExtractableResponse<Response> response = 베어러_인증으로_내_회원_정보_조회_요청(invalidAccessToken);
	assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
}
```

그런데 이 경우 myInfoWithBasicAuth 및 myInfoWithSession 테스트가 실패하였기에 BearerTokenAuthenticationFilter의 preHandle 메소드 내부를 try-catch문으로 감싸주었습니다. 헌데, 개념이 부족해서인지 왜 다른 인터셉터의 변경이 다른 인증 테스트에 영향을 미치는지 잘 모르겠습니다. **왜 try-catch로 감싸지 않으면 타 테스트에 영향을 미치는 걸까요..?**

AuthConfig 클래스의 addInterceptors 메소드를 보면 복수의 인터셉터들이 순서대로 등록되어 있는데요. 여기서 첫 번째 등록된 SecurityContextPersistenceFilter만 필수고 **이후의 것들은 선택사항이 맞나요?** 즉 폼 기반 인증은 UsernamePasswordAuthenticationFilter, 베이직 인증은 BasicAuthenticationFilter, 베어러 인증은 BearerTokenAuthenticationFilter... **TokenAuthenticationInterceptor는 어떤 인증과 관련이 있는 걸까요..?**

**인터셉터마다 true만을 리턴(BasicAuthenticationFilter)하기도 하고, true/false를 리턴(UsernamePasswordAuthenticationFilter)하기도, false만을 리턴(TokenAuthenticationInterceptor)하기도 하는데 이해가 잘 가지 않습니다..**
