### PR TITLE
[인수 테스트와 인증] 2단계 - 깃헙 로그인

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,50 @@ Content-Type: application/json
 - 내 정보 조회 예외 인수 테스트
   - 토큰 발급 없이, 내 정보를 조회한다.
   - 예외가 발생한다.
+
+
+# 2단계 - 깃헙 로그인
+## 요구사항
+### 기능 요구사항
+- 깃허브를 이용한 로그인 구현(토큰 발행)
+- 가입이 되어있지 않은 경우, 회원 가입으로 진행 후 토큰 발행
+
+### 프로그래밍 요구사항
+- GitHub 로그인을 검증할 수 있는 인수 테스트 구현(실제 GitHub 에 요청을 하지 않아도 됨)
+
+## 요구사항 설명
+### 깃헙 로그인 API
+- `AuthAcceptanceTest` 테스트 만들기
+
+#### Request
+```http request
+POST /login/github HTTP/1.1
+content-type: application/json
+host: localhost:8080
+
+{
+    "code": "qwerasdfzxvcqwerasdfzxcv"
+}
+```
+
+#### Response
+- accessToken는 깃헙으로부터 받아온 정보가 아니라 subway 서비스에서 생성한 토큰
+- 아이디/패스워드를 이용한 로그인 시 응답받는 토큰과 동일한 토큰
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjcyNjUyMzAwLCJleHAiOjE2NzI2NTU5MDAsInJvbGVzIjpbIlJPTEVfQURNSU4iLCJST0xFX0FETUlOIl19.uaUXk5GkqB6QE_qlZisk3RZ3fL74zDADqbJl6LoLkSc"
+}
+```
+
+### code 별 응답 response
+- 매번 실제 깃헙 서비스에 요청을 보낼 수 없으니 어떤 코드로 요청이 오면 정해진 response 를 응답하는 구조를 만든다.
+
+
+### 요구사항 기반 시나리오
+- Github 에 이미 등록된 유저의 권한증서(code) 를 가지고
+  - Github Auth Server (fake) 로 로그인 요청한다.
+  - Github Auth Server 로 부터 발급받은 accessToken 으로 Github Resource Server (fake) 로 깃헙 프로필(이메일)을 요청한다.
+  - 받아온 이메일로 member 를 조회한다.
+    - member 가 존재하지 않으면 새로운 멤버를 우리 서버에 등록한다.
+      - 해당 멤버의 토큰을 발급한다.
+    - member 가 존재하면 해당 멤버의 토큰을 발급한다.

--- a/src/main/java/nextstep/auth/application/AuthService.java
+++ b/src/main/java/nextstep/auth/application/AuthService.java
@@ -14,10 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final GithubClient githubClient;
 
-    public AuthService(JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository) {
+    public AuthService(JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository, GithubClient githubClient) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.memberRepository = memberRepository;
+        this.githubClient = githubClient;
     }
 
     public TokenResponse login(TokenRequest tokenRequest) {
@@ -27,5 +29,20 @@ public class AuthService {
 
         String token = jwtTokenProvider.createToken(member.getEmail(), member.getRoles());
         return new TokenResponse(token);
+    }
+
+    public TokenResponse loginGithub(String code) {
+        String accessTokenFromGithub = githubClient.getAccessTokenFromGithub(code);
+        String githubEmail = githubClient.getGithubProfileFromGithub(accessTokenFromGithub).getEmail();
+
+        Member member = findMemberOrElseGet(githubEmail);
+
+        String token = jwtTokenProvider.createToken(member.getEmail(), member.getRoles());
+        return new TokenResponse(token);
+    }
+
+    private Member findMemberOrElseGet(String githubEmail) {
+        return memberRepository.findByEmail(githubEmail)
+                .orElseGet(() -> memberRepository.save(new Member(githubEmail)));
     }
 }

--- a/src/main/java/nextstep/auth/application/AuthService.java
+++ b/src/main/java/nextstep/auth/application/AuthService.java
@@ -12,8 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class AuthService {
-    private JwtTokenProvider jwtTokenProvider;
-    private MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     public AuthService(JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository) {
         this.jwtTokenProvider = jwtTokenProvider;

--- a/src/main/java/nextstep/auth/application/GithubClient.java
+++ b/src/main/java/nextstep/auth/application/GithubClient.java
@@ -1,0 +1,9 @@
+package nextstep.auth.application;
+
+import nextstep.auth.dto.GithubProfileResponse;
+
+public interface GithubClient {
+    String getAccessTokenFromGithub(String code);
+
+    GithubProfileResponse getGithubProfileFromGithub(String accessToken);
+}

--- a/src/main/java/nextstep/auth/application/GithubClientImpl.java
+++ b/src/main/java/nextstep/auth/application/GithubClientImpl.java
@@ -1,0 +1,73 @@
+package nextstep.auth.application;
+
+import nextstep.auth.dto.GithubAccessTokenRequest;
+import nextstep.auth.dto.GithubAccessTokenResponse;
+import nextstep.auth.dto.GithubProfileResponse;
+import nextstep.auth.exception.AuthenticationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+
+@Component
+public class GithubClientImpl implements GithubClient {
+    @Value("${github.client.id}")
+    private String clientId;
+    @Value("${github.client.secret}")
+    private String clientSecret;
+    @Value("${github.url.access-token}")
+    private String tokenUrl;
+    @Value("${github.url.profile}")
+    private String profileUrl;
+
+    @Override
+    public String getAccessTokenFromGithub(String code) {
+        GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(
+                code,
+                clientId,
+                clientSecret
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(
+                githubAccessTokenRequest, headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        String accessToken = Objects.requireNonNull(restTemplate
+                        .exchange(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
+                        .getBody())
+                .getAccessToken();
+        if (accessToken == null) {
+            throw new AuthenticationException();
+        }
+        return accessToken;
+    }
+
+    @Override
+    public GithubProfileResponse getGithubProfileFromGithub(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "token " + accessToken);
+
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        try {
+            return restTemplate
+                    .exchange(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class)
+                    .getBody();
+        } catch (HttpClientErrorException e) {
+            throw new AuthenticationException();
+        }
+    }
+}

--- a/src/main/java/nextstep/auth/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/nextstep/auth/dto/GithubAccessTokenRequest.java
@@ -1,0 +1,25 @@
+package nextstep.auth.dto;
+
+public class GithubAccessTokenRequest {
+    private String code;
+    private String clientId;
+    private String clientSecret;
+
+    public GithubAccessTokenRequest(String code, String clientId, String clientSecret) {
+        this.code = code;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+}

--- a/src/main/java/nextstep/auth/dto/GithubAccessTokenResponse.java
+++ b/src/main/java/nextstep/auth/dto/GithubAccessTokenResponse.java
@@ -1,0 +1,13 @@
+package nextstep.auth.dto;
+
+public class GithubAccessTokenResponse {
+    private String accessToken;
+
+    public GithubAccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return this.accessToken;
+    }
+}

--- a/src/main/java/nextstep/auth/dto/GithubLoginRequest.java
+++ b/src/main/java/nextstep/auth/dto/GithubLoginRequest.java
@@ -1,0 +1,9 @@
+package nextstep.auth.dto;
+
+public class GithubLoginRequest {
+    private String code;
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/nextstep/auth/dto/GithubProfileResponse.java
+++ b/src/main/java/nextstep/auth/dto/GithubProfileResponse.java
@@ -1,0 +1,13 @@
+package nextstep.auth.dto;
+
+public class GithubProfileResponse {
+    private String email;
+
+    public GithubProfileResponse(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/nextstep/auth/exception/ErrorCode.java
+++ b/src/main/java/nextstep/auth/exception/ErrorCode.java
@@ -3,6 +3,7 @@ package nextstep.auth.exception;
 import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
+    NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자 입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자 입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근할 수 없는 사용자입니다.");
 

--- a/src/main/java/nextstep/auth/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/auth/exception/GlobalExceptionHandler.java
@@ -20,6 +20,13 @@ public class GlobalExceptionHandler {
                 .body(makeErrorResponse(errorCode));
     }
 
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
         return new ErrorResponse(errorCode.name(), errorCode.getMessage());
     }

--- a/src/main/java/nextstep/auth/exception/NotFoundException.java
+++ b/src/main/java/nextstep/auth/exception/NotFoundException.java
@@ -1,0 +1,13 @@
+package nextstep.auth.exception;
+
+public class NotFoundException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public NotFoundException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/nextstep/auth/ui/AppMemberArgumentResolver.java
+++ b/src/main/java/nextstep/auth/ui/AppMemberArgumentResolver.java
@@ -43,7 +43,7 @@ public class AppMemberArgumentResolver implements HandlerMethodArgumentResolver 
 
     private String extractToken(String headerValue) {
         if (headerValue == null || !isBearerType(headerValue)) {
-            return null;
+            throw new AuthorizationException();
         }
 
         return headerValue.substring(BEARER_TYPE.length());

--- a/src/main/java/nextstep/auth/ui/AuthController.java
+++ b/src/main/java/nextstep/auth/ui/AuthController.java
@@ -9,10 +9,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class AutoController {
+public class AuthController {
     private AuthService authService;
 
-    public AutoController(AuthService authService) {
+    public AuthController(AuthService authService) {
         this.authService = authService;
     }
 

--- a/src/main/java/nextstep/auth/ui/AuthController.java
+++ b/src/main/java/nextstep/auth/ui/AuthController.java
@@ -1,6 +1,7 @@
 package nextstep.auth.ui;
 
 import nextstep.auth.application.AuthService;
+import nextstep.auth.dto.GithubLoginRequest;
 import nextstep.auth.dto.TokenRequest;
 import nextstep.auth.dto.TokenResponse;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,12 @@ public class AuthController {
     @PostMapping("/login/token")
     public ResponseEntity<TokenResponse> login(@RequestBody TokenRequest tokenRequest) {
         TokenResponse tokenResponse = authService.login(tokenRequest);
+        return ResponseEntity.ok().body(tokenResponse);
+    }
+
+    @PostMapping("/login/github")
+    public ResponseEntity<TokenResponse> loginGithub(@RequestBody GithubLoginRequest githubLoginRequest) {
+        TokenResponse tokenResponse = authService.loginGithub(githubLoginRequest.getCode());
         return ResponseEntity.ok().body(tokenResponse);
     }
 }

--- a/src/main/java/nextstep/member/application/MemberService.java
+++ b/src/main/java/nextstep/member/application/MemberService.java
@@ -1,5 +1,7 @@
 package nextstep.member.application;
 
+import nextstep.auth.exception.ErrorCode;
+import nextstep.auth.exception.NotFoundException;
 import nextstep.member.application.dto.MemberRequest;
 import nextstep.member.application.dto.MemberResponse;
 import nextstep.member.domain.Member;
@@ -39,6 +41,6 @@ public class MemberService {
     }
 
     private Member findMemberById(Long id) {
-        return memberRepository.findById(id).orElseThrow(RuntimeException::new);
+        return memberRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/nextstep/member/domain/Member.java
+++ b/src/main/java/nextstep/member/domain/Member.java
@@ -25,6 +25,10 @@ public class Member {
     public Member() {
     }
 
+    public Member(String email) {
+        this.email = email;
+    }
+
     public Member(String email, String password, Integer age) {
         this.email = email;
         this.password = password;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,8 @@ spring.jpa.properties.hibernate.format_sql=true
 
 security.jwt.token.secret-key= atdd-secret-key
 security.jwt.token.expire-length= 3600000
+
+github.client.id= id
+github.client.secret= secret
+github.url.access-token= access-token
+github.url.profile= profile

--- a/src/test/java/nextstep/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/auth/acceptance/AuthAcceptanceTest.java
@@ -3,10 +3,18 @@ package nextstep.auth.acceptance;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.AcceptanceTest;
+import nextstep.auth.acceptance.fake.FakeGithubResponses;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.auth.acceptance.AuthSteps.깃헙_로그인_요청_성공;
+import static nextstep.auth.acceptance.AuthSteps.깃헙_로그인_요청_실패;
 import static nextstep.member.acceptance.MemberSteps.베어러_인증_로그인_요청_성공;
 import static nextstep.member.acceptance.MemberSteps.베어러_인증_로그인_요청_실패;
 import static nextstep.member.acceptance.MemberSteps.회원_생성_요청;
@@ -68,5 +76,62 @@ class AuthAcceptanceTest extends AcceptanceTest {
 
         // when & then
         베어러_인증_로그인_요청_실패(EMAIL, invalidPassword);
+    }
+
+    /**
+     * given Github 에서 받은, 서버에 이미 등록된 유저의 권한증서(code)를 가지고
+     * when Github 로 로그인 요청하면
+     * then 우리 서버의 토큰을 발급받을 수 있다.
+     */
+    @DisplayName("Github Auth : Github 에서 받은 이미 등록된 유저의 권한증서(code)를 이용하여 로그인 요청 하면 액세스 토큰을 받는다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"사용자1", "사용자2", "사용자3", "사용자4"})
+    void githubAuthLoginAlreadyMember(FakeGithubResponses fakeGithubResponses) {
+        // given
+        회원_생성_요청(fakeGithubResponses.getEmail(), PASSWORD, AGE);
+        Map<String, String> params = new HashMap<>();
+        params.put("code", fakeGithubResponses.getCode());
+
+        // when
+        ExtractableResponse<Response> response = 깃헙_로그인_요청_성공(params);
+
+        // then
+        assertThat(response.jsonPath().getString("accessToken")).isNotBlank();
+    }
+
+    /**
+     * given Github 에서 받은, 서버에 등록되지 않은 유저의 권한증서(code)를 가지고
+     * when Github 로 로그인 요청하면
+     * then 우리 서버의 토큰을 발급받을 수 있다.
+     */
+    @DisplayName("Github Auth : Github 에서 받은 이미 등록된 유저의 권한증서(code)를 이용하여 로그인 요청 하면 액세스 토큰을 받는다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"사용자1", "사용자2", "사용자3", "사용자4"})
+    void githubAuthLoginCreateMember(FakeGithubResponses fakeGithubResponses) {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("code", fakeGithubResponses.getCode());
+
+        // when
+        ExtractableResponse<Response> response = 깃헙_로그인_요청_성공(params);
+
+        // then
+        assertThat(response.jsonPath().getString("accessToken")).isNotBlank();
+    }
+
+    /**
+     * given Github 에 없는 권한증서(code)를 가지고
+     * when Github 로 로그인 요청하면
+     * then 우리 서버의 토큰을 발급받을 수 없다.
+     */
+    @DisplayName("Github Auth : Github 에 없는 권한증서(code)로 로그인 요청하면 토큰을 발급받을 수 없다.")
+    @Test
+    void githubAuthLoginExceptionNotContainsCode() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("code", "code");
+
+        // when & then
+        깃헙_로그인_요청_실패(params);
     }
 }

--- a/src/test/java/nextstep/auth/acceptance/AuthSteps.java
+++ b/src/test/java/nextstep/auth/acceptance/AuthSteps.java
@@ -1,0 +1,30 @@
+package nextstep.auth.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class AuthSteps {
+    public static ExtractableResponse<Response> 깃헙_로그인_요청_성공(Map<String, String> params) {
+        return 깃헙_로그인_요청(params)
+                .statusCode(HttpStatus.OK.value()).extract();
+    }
+
+    public static ExtractableResponse<Response> 깃헙_로그인_요청_실패(Map<String, String> params) {
+        return 깃헙_로그인_요청(params)
+                .statusCode(HttpStatus.UNAUTHORIZED.value()).extract();
+    }
+
+    private static ValidatableResponse 깃헙_로그인_요청(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/login/github")
+                .then().log().all();
+    }
+}

--- a/src/test/java/nextstep/auth/acceptance/fake/FakeGithubClientImpl.java
+++ b/src/test/java/nextstep/auth/acceptance/fake/FakeGithubClientImpl.java
@@ -1,0 +1,22 @@
+package nextstep.auth.acceptance.fake;
+
+import nextstep.auth.application.GithubClient;
+import nextstep.auth.dto.GithubProfileResponse;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+@Profile("test")
+public class FakeGithubClientImpl implements GithubClient {
+    @Override
+    public String getAccessTokenFromGithub(String code) {
+        return FakeGithubResponses.findAccessTokenByCode(code);
+    }
+
+    @Override
+    public GithubProfileResponse getGithubProfileFromGithub(String accessToken) {
+        return FakeGithubResponses.findEmailByAccessToken(accessToken);
+    }
+}

--- a/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
+++ b/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
@@ -1,0 +1,51 @@
+package nextstep.auth.acceptance.fake;
+
+import nextstep.auth.dto.GithubProfileResponse;
+import nextstep.auth.exception.AuthenticationException;
+
+import java.util.Arrays;
+
+public enum FakeGithubResponses {
+    사용자1("832ovnq039hfjn", "access_token_1", "email1@email.com"),
+    사용자2("mkfo0aFa03m", "access_token_2", "email2@email.com"),
+    사용자3("m-a3hnfnoew92", "access_token_3", "email3@email.com"),
+    사용자4("nvci383mciq0oq", "access_token_4", "email4@email.com");
+
+    private String code;
+    private String accessToken;
+    private String email;
+
+    FakeGithubResponses(String code, String accessToken, String email) {
+        this.code = code;
+        this.accessToken = accessToken;
+        this.email = email;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public static String findAccessTokenByCode(String code) {
+        return Arrays.stream(values())
+                .filter(it -> it.code.equals(code))
+                .findFirst()
+                .map(it -> it.accessToken)
+                .orElseThrow(AuthenticationException::new);
+    }
+
+    public static GithubProfileResponse findEmailByAccessToken(String accessToken) {
+        return Arrays.stream(values())
+                .filter(it -> it.accessToken.equals(accessToken))
+                .findFirst()
+                .map(it -> new GithubProfileResponse(it.email))
+                .orElseThrow(AuthenticationException::new);
+    }
+}

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -3,7 +3,6 @@ package nextstep.member.acceptance;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.AcceptanceTest;
-import nextstep.auth.dto.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -96,10 +95,10 @@ class MemberAcceptanceTest extends AcceptanceTest {
     void getMyInfo() {
         // given
         회원_생성_요청(EMAIL, PASSWORD, AGE);
-        TokenResponse tokenResponse = 베어러_인증_로그인_요청_성공(EMAIL, PASSWORD).response().as(TokenResponse.class);
+        String accessToken = 베어러_인증_로그인_요청_성공(EMAIL, PASSWORD).response().jsonPath().getString("accessToken");
 
         // when
-        ExtractableResponse<Response> getMyInfoResponse = 베이러_인증으로_내_회원_정보_조회_요청(tokenResponse.getAccessToken());
+        ExtractableResponse<Response> getMyInfoResponse = 베이러_인증으로_내_회원_정보_조회_요청(accessToken);
 
         // then
         Long id = getMyInfoResponse.jsonPath().getLong("id");


### PR DESCRIPTION
안녕하세요 이슬님!

2단계 미션 진행 후 PR 요청 드립니다!

깃헙 로그인 요청하는 부분을 GithubClient 인터페이스 -> FakeGithubClientImpl 로 fake 구현체로 인수 테스트 작성해보았습니다.

미션하면서 궁금했던 내용이 있었는데, 실제 프로덕션 코드에 대한 개발자 검증을 위해 실제 `GithubClientImpl` 객체에서 프로퍼티로 주입받는 tokenUrl 을 https://github.com/login/oauth/access_token 로 요청하는 과정을 postman 을 이용하였는데, 클라이언트(프론트)에서 받을 권한증서(code) 값을 모른다는 점과, POST https://github.com/login/oauth/access_token 요청에 대한 404 가 떨어졌습니다 ..

이번 미션의 의도가 프로덕션 코드에 대한 검증 + 외부 API를 Fake로 테스트하기 둘다 검증하는게 맞을까요 ..? (아니면 이번 미션에서는 테스트 코드에 대한 고민만 하면 되는 걸까요?)
우선 테스트 코드 테스트를 먼저 작성 후 PR 요청 드립니다 ..!

이번 미션 리뷰도 잘 부탁드립니다!