### PR TITLE
Step3 - 즐겨찾기 기능 구현

### DIFF
--- a/src/main/java/nextstep/member/ui/NotExistsTokenException.java
+++ b/src/main/java/nextstep/member/ui/NotExistsTokenException.java
@@ -1,0 +1,7 @@
+package nextstep.member.ui;
+
+public class NotExistsTokenException extends RuntimeException {
+    public NotExistsTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/FavoriteService.java
+++ b/src/main/java/nextstep/subway/applicaion/FavoriteService.java
@@ -1,0 +1,48 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.FavoriteResponse;
+import nextstep.subway.domain.Favorite;
+import nextstep.subway.domain.FavoriteRepository;
+import nextstep.subway.domain.Station;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class FavoriteService {
+    private FavoriteRepository favoriteRepository;
+    private StationService stationService;
+
+    public FavoriteService(FavoriteRepository favoriteRepository, StationService stationService) {
+        this.favoriteRepository = favoriteRepository;
+        this.stationService = stationService;
+    }
+
+    @Transactional
+    public FavoriteResponse saveFavorite(Long memberId, Long sourceStationId, Long targetStationId) {
+        Station sourceStation = stationService.findById(sourceStationId);
+        Station targetStation = stationService.findById(targetStationId);
+
+        Favorite favorite = favoriteRepository.save(new Favorite(memberId, sourceStation, targetStation));
+        return FavoriteResponse.of(favorite);
+    }
+
+    public List<FavoriteResponse> findByMember(long memberId) {
+        List<Favorite> favorites = favoriteRepository.findAllByMemberId(memberId);
+        return favorites.stream()
+                .map(FavoriteResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteFavorite(Long favoriteId) {
+        Favorite favorite = favoriteRepository.findById(favoriteId)
+                .orElseThrow(() -> new RuntimeException(""));
+
+        favoriteRepository.delete(favorite);
+    }
+
+}

--- a/src/main/java/nextstep/subway/applicaion/FavoriteService.java
+++ b/src/main/java/nextstep/subway/applicaion/FavoriteService.java
@@ -1,7 +1,6 @@
 package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.FavoriteResponse;
-import nextstep.subway.applicaion.exceptions.CanNotDeleteFavoriteException;
 import nextstep.subway.applicaion.exceptions.NotFoundFavoriteException;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -45,10 +43,8 @@ public class FavoriteService {
         Favorite favorite = favoriteRepository.findById(favoriteId)
                 .orElseThrow(() -> new NotFoundFavoriteException("존재하지 않는 즐겨찾기 아이디 입니다. favoriteId: " + favoriteId));
 
-        if (!Objects.equals(favorite.getMemberId(), memberId)) {
-            throw new CanNotDeleteFavoriteException("다른 사람의 즐겨찾기를 삭제할 수 없습니다. memberId: " + memberId);
-        }
-        
+        favorite.delete(memberId);
+
         favoriteRepository.delete(favorite);
     }
 

--- a/src/main/java/nextstep/subway/applicaion/FavoriteService.java
+++ b/src/main/java/nextstep/subway/applicaion/FavoriteService.java
@@ -1,6 +1,7 @@
 package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.FavoriteResponse;
+import nextstep.subway.applicaion.exceptions.CanNotDeleteFavoriteException;
 import nextstep.subway.applicaion.exceptions.NotFoundFavoriteException;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,10 +41,14 @@ public class FavoriteService {
     }
 
     @Transactional
-    public void deleteFavorite(Long favoriteId) {
+    public void deleteFavorite(Long favoriteId, Long memberId) {
         Favorite favorite = favoriteRepository.findById(favoriteId)
                 .orElseThrow(() -> new NotFoundFavoriteException("존재하지 않는 즐겨찾기 아이디 입니다. favoriteId: " + favoriteId));
 
+        if (!Objects.equals(favorite.getMemberId(), memberId)) {
+            throw new CanNotDeleteFavoriteException("다른 사람의 즐겨찾기를 삭제할 수 없습니다. memberId: " + memberId);
+        }
+        
         favoriteRepository.delete(favorite);
     }
 

--- a/src/main/java/nextstep/subway/applicaion/FavoriteService.java
+++ b/src/main/java/nextstep/subway/applicaion/FavoriteService.java
@@ -1,6 +1,7 @@
 package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.FavoriteResponse;
+import nextstep.subway.applicaion.exceptions.NotFoundFavoriteException;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
 import nextstep.subway.domain.Station;
@@ -40,7 +41,7 @@ public class FavoriteService {
     @Transactional
     public void deleteFavorite(Long favoriteId) {
         Favorite favorite = favoriteRepository.findById(favoriteId)
-                .orElseThrow(() -> new RuntimeException(""));
+                .orElseThrow(() -> new NotFoundFavoriteException("존재하지 않는 즐겨찾기 아이디 입니다. favoriteId: " + favoriteId));
 
         favoriteRepository.delete(favorite);
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/FavoriteResponse.java
@@ -1,0 +1,35 @@
+package nextstep.subway.applicaion.dto;
+
+import nextstep.subway.domain.Favorite;
+
+public class FavoriteResponse {
+    private Long id;
+    private StationResponse source;
+    private StationResponse target;
+
+    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+        this.id = id;
+        this.source = source;
+        this.target = target;
+    }
+
+    public static FavoriteResponse of(Favorite favorite) {
+        return new FavoriteResponse(
+                favorite.getId(),
+                StationResponse.of(favorite.getSource()),
+                StationResponse.of(favorite.getTarget())
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StationResponse getSource() {
+        return source;
+    }
+
+    public StationResponse getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exceptions/CanNotDeleteFavoriteException.java
+++ b/src/main/java/nextstep/subway/applicaion/exceptions/CanNotDeleteFavoriteException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.applicaion.exceptions;
+
+public class CanNotDeleteFavoriteException extends RuntimeException {
+    public CanNotDeleteFavoriteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exceptions/NotFoundFavoriteException.java
+++ b/src/main/java/nextstep/subway/applicaion/exceptions/NotFoundFavoriteException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.applicaion.exceptions;
+
+public class NotFoundFavoriteException extends RuntimeException {
+    public NotFoundFavoriteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/domain/Favorite.java
@@ -1,0 +1,42 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne
+    @JoinColumn(name = "source_id")
+    private Station source;
+
+    @ManyToOne
+    @JoinColumn(name = "target_id")
+    private Station target;
+
+    public Favorite(Long memberId, Station source, Station target) {
+        this.memberId = memberId;
+        this.source = source;
+        this.target = target;
+    }
+
+    public Favorite() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Station getSource() {
+        return source;
+    }
+
+    public Station getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/domain/Favorite.java
@@ -32,6 +32,10 @@ public class Favorite {
         return id;
     }
 
+    public Long getMemberId() {
+        return memberId;
+    }
+
     public Station getSource() {
         return source;
     }

--- a/src/main/java/nextstep/subway/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/domain/Favorite.java
@@ -1,6 +1,9 @@
 package nextstep.subway.domain;
 
+import nextstep.subway.domain.exceptions.CanNotDeleteFavoriteException;
+
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
 public class Favorite {
@@ -28,12 +31,14 @@ public class Favorite {
     public Favorite() {
     }
 
-    public Long getId() {
-        return id;
+    public void delete(Long memberId) {
+        if (!Objects.equals(this.memberId, memberId)) {
+            throw new CanNotDeleteFavoriteException("다른 사람의 즐겨찾기를 삭제할 수 없습니다. memberId: " + memberId);
+        }
     }
 
-    public Long getMemberId() {
-        return memberId;
+    public Long getId() {
+        return id;
     }
 
     public Station getSource() {

--- a/src/main/java/nextstep/subway/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/domain/FavoriteRepository.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    
+}

--- a/src/main/java/nextstep/subway/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/domain/FavoriteRepository.java
@@ -2,6 +2,8 @@ package nextstep.subway.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
-    
+    List<Favorite> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/nextstep/subway/domain/exceptions/CanNotDeleteFavoriteException.java
+++ b/src/main/java/nextstep/subway/domain/exceptions/CanNotDeleteFavoriteException.java
@@ -1,4 +1,4 @@
-package nextstep.subway.applicaion.exceptions;
+package nextstep.subway.domain.exceptions;
 
 public class CanNotDeleteFavoriteException extends RuntimeException {
     public CanNotDeleteFavoriteException(String message) {

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -2,7 +2,7 @@ package nextstep.subway.ui;
 
 import nextstep.member.ui.InvalidTokenException;
 import nextstep.member.ui.NotExistsTokenException;
-import nextstep.subway.applicaion.exceptions.CanNotDeleteFavoriteException;
+import nextstep.subway.domain.exceptions.CanNotDeleteFavoriteException;
 import nextstep.subway.applicaion.exceptions.NotFoundFavoriteException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -2,6 +2,7 @@ package nextstep.subway.ui;
 
 import nextstep.member.ui.InvalidTokenException;
 import nextstep.member.ui.NotExistsTokenException;
+import nextstep.subway.applicaion.exceptions.CanNotDeleteFavoriteException;
 import nextstep.subway.applicaion.exceptions.NotFoundFavoriteException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -29,5 +30,10 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(NotFoundFavoriteException.class)
     public ResponseEntity<Void> handleNotFoundException(NotFoundFavoriteException e) {
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(CanNotDeleteFavoriteException.class)
+    public ResponseEntity<Void> handleForbiddenException(CanNotDeleteFavoriteException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -2,6 +2,7 @@ package nextstep.subway.ui;
 
 import nextstep.member.ui.InvalidTokenException;
 import nextstep.member.ui.NotExistsTokenException;
+import nextstep.subway.applicaion.exceptions.NotFoundFavoriteException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,5 +24,10 @@ public class ControllerExceptionHandler {
     @ExceptionHandler({InvalidTokenException.class, NotExistsTokenException.class})
     public ResponseEntity<Void> handleUnauthorizedException(RuntimeException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(NotFoundFavoriteException.class)
+    public ResponseEntity<Void> handleNotFoundException(NotFoundFavoriteException e) {
+        return ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,6 +1,9 @@
 package nextstep.subway.ui;
 
+import nextstep.member.ui.InvalidTokenException;
+import nextstep.member.ui.NotExistsTokenException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,5 +18,10 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Void> handleIllegalArgsException(IllegalArgumentException e) {
         return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler({InvalidTokenException.class, NotExistsTokenException.class})
+    public ResponseEntity<Void> handleUnauthorizedException(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -2,16 +2,16 @@ package nextstep.subway.ui;
 
 import nextstep.member.ui.LoginMember;
 import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
 import nextstep.subway.domain.Station;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/favorites")
@@ -31,5 +31,48 @@ public class FavoriteController {
 
         Favorite favorite = favoriteRepository.save(new Favorite(loginMember.getId(), sourceStation, targetStation));
         return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FavoriteResponse>> readLine(LoginMember loginMember) {
+        List<Favorite> myFavorites = favoriteRepository.findAllByMemberId(loginMember.getId());
+
+        List<FavoriteResponse> response = myFavorites.stream()
+                .map(FavoriteResponse::of)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+}
+
+class FavoriteResponse {
+    private Long id;
+    private StationResponse source;
+    private StationResponse target;
+
+    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+        this.id = id;
+        this.source = source;
+        this.target = target;
+    }
+
+    public static FavoriteResponse of(Favorite favorite) {
+        return new FavoriteResponse(
+                favorite.getId(),
+                StationResponse.of(favorite.getSource()),
+                StationResponse.of(favorite.getTarget())
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StationResponse getSource() {
+        return source;
+    }
+
+    public StationResponse getTarget() {
+        return target;
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -45,7 +45,7 @@ public class FavoriteController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteLine(LoginMember loginMember, @PathVariable Long id) {
         Favorite favorite = favoriteRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException(""));
 

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -42,7 +42,7 @@ public class FavoriteController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteLine(LoginMember loginMember, @PathVariable Long id) {
-        favoriteService.deleteFavorite(id);
+        favoriteService.deleteFavorite(id, loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -43,6 +43,16 @@ public class FavoriteController {
 
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
+        Favorite favorite = favoriteRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException(""));
+
+        favoriteRepository.delete(favorite);
+
+        return ResponseEntity.noContent().build();
+    }
 }
 
 class FavoriteResponse {

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -1,0 +1,35 @@
+package nextstep.subway.ui;
+
+import nextstep.member.ui.LoginMember;
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.domain.Favorite;
+import nextstep.subway.domain.FavoriteRepository;
+import nextstep.subway.domain.Station;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/favorites")
+public class FavoriteController {
+    private FavoriteRepository favoriteRepository;
+    private StationService stationService;
+
+    public FavoriteController(FavoriteRepository favoriteRepository, StationService stationService) {
+        this.favoriteRepository = favoriteRepository;
+        this.stationService = stationService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createLine(LoginMember loginMember, @RequestBody FavoriteRequest favoriteRequest) {
+        Station sourceStation = stationService.findById(favoriteRequest.getSource());
+        Station targetStation = stationService.findById(favoriteRequest.getTarget());
+
+        Favorite favorite = favoriteRepository.save(new Favorite(loginMember.getId(), sourceStation, targetStation));
+        return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).build();
+    }
+}

--- a/src/main/java/nextstep/subway/ui/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteRequest.java
@@ -1,0 +1,17 @@
+package nextstep.subway.ui;
+
+public class FavoriteRequest {
+    private Long source;
+    private Long target;
+
+    public FavoriteRequest() {
+    }
+
+    public Long getSource() {
+        return source;
+    }
+
+    public Long getTarget() {
+        return target;
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -72,7 +72,6 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .get("/favorites")
                 .then().log().all()

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -80,7 +80,7 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(() -> {
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
             assertThat(response.body().jsonPath().getList("source.id", Long.class)).containsExactly(강남역, 양재시민의숲역);
             assertThat(response.body().jsonPath().getList("target.id", Long.class)).containsExactly(양재역, 청계산입구역);
         });

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -183,6 +183,28 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
         assertThat(즐겨찾기_삭제_응답.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
+    /**
+     * WHEN 로그인한 유저가 존재하지 않는 즐겨찾기를 삭제하는 경우 <br>
+     * THEN 예외가 발생한다 <br>
+     */
+    @DisplayName("로그인한 유저가 존재하지 않는 즐겨찾기 삭제")
+    @Test
+    void deleteNotExistsFavorite() {
+        // given
+        Long 존재하지_않는_즐겨찾기_아이디 = Long.MAX_VALUE;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/favorites/" + 존재하지_않는_즐겨찾기_아이디)
+                .then().log().all()
+                .extract();
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
     private ExtractableResponse<Response> 즐겨찾기_추가_요청(String accessToken, Long source, Long target) {
         Map<String, String> params = new HashMap<>();
         params.put("source", source + "");

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -6,6 +6,9 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -47,14 +50,30 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
      * WHEN 로그인한 회원이 출발역과 도착역을 즐겨찾기 하는 경우 <br>
      * THEN 즐겨찾기가 추가된다 <br>
      */
-    @DisplayName("즐겨찾기 추가")
+    @DisplayName("로그인한 유저가 즐겨찾기 추가")
     @Test
-    void addFavorite() {
+    void addFavoriteLoginUser() {
         // when
-        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(강남역, 양재역);
+        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(accessToken, 강남역, 양재역);
 
         // then
         assertThat(즐겨찾기_추가_응답.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    /**
+     * WHEN 로그인하지 않거나, 유효하지 않은 회원 인증정보로 출발역과 도착역을 즐겨찾기 하는 경우 <br>
+     * THEN 예외가 발생한다 <br>
+     */
+    @DisplayName("로그인 하지 않은 유저가 즐겨찾기 추가")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"Bearer abcd"})
+    void addFavoriteNotLoginUser(String illegalAccessToken) {
+        // when
+        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(illegalAccessToken, 강남역, 양재역);
+
+        // then
+        assertThat(즐겨찾기_추가_응답.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     /**
@@ -62,12 +81,12 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
      * WHEN 로그인한 회원이 즐겨찾기 조회하는 경우 <br>
      * THEN 2개의 즐겨찾기 목록이 조회된다 <br>
      */
-    @DisplayName("즐겨찾기 조회")
+    @DisplayName("로그인한 유저가 즐겨찾기 조회")
     @Test
-    void readFavorite() {
+    void readFavoriteLoginUser() {
         // given
-        즐겨찾기_추가_요청(강남역, 양재역);
-        즐겨찾기_추가_요청(양재시민의숲역, 청계산입구역);
+        즐겨찾기_추가_요청(accessToken, 강남역, 양재역);
+        즐겨찾기_추가_요청(accessToken, 양재시민의숲역, 청계산입구역);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -86,15 +105,40 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * WHEN 로그인하지 않거나, 유효하지 않은 회원 인증정보로 즐겨찾기 조회하는 경우 <br>
+     * THEN 예외가 발생한다 <br>
+     */
+    @DisplayName("로그인하지 않은 유저가 즐겨찾기 조회")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"Bearer abcd"})
+    void readFavoriteNotLoginUser(String illegalAccessToken) {
+        // when
+        var given = RestAssured.given().log().all();
+
+        if (illegalAccessToken != null) {
+            given.auth().oauth2(illegalAccessToken);
+        }
+
+        var 즐겨찾기_조회_응답 = given.when()
+                .get("/favorites")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(즐겨찾기_조회_응답.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    /**
      * GIVEN 로그인한 회원이 즐겨찾기를 하고 <br>
      * WHEN 즐겨찾기를 삭제하는 경우 <br>
      * THEN 즐겨찾기가 삭제된다 <br>
      */
-    @DisplayName("즐겨찾기 삭제")
+    @DisplayName("로그인한 유저가 즐겨찾기 삭제")
     @Test
-    void deleteFavorite() {
+    void deleteFavoriteLoginUser() {
         // given
-        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(강남역, 양재역);
+        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(accessToken, 강남역, 양재역);
         String location = 즐겨찾기_추가_응답.header("location");
 
         // when
@@ -109,16 +153,51 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    private ExtractableResponse<Response> 즐겨찾기_추가_요청(Long source, Long target) {
+    /**
+     * WHEN 로그인하지 않거나, 유효하지 않은 회원 인증정보로 즐겨찾기 삭제하는 경우 <br>
+     * THEN 예외가 발생한다 <br>
+     */
+    @DisplayName("로그인하지 않은 유저가 즐겨찾기 삭제")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"Bearer abcd"})
+    void deleteFavoriteNotLoginUser(String illegalAccessToken) {
+        // given
+        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(accessToken, 강남역, 양재역);
+        String location = 즐겨찾기_추가_응답.header("location");
+
+        // when
+        var given = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        if (illegalAccessToken != null) {
+            given.auth().oauth2(illegalAccessToken);
+        }
+
+        var 즐겨찾기_삭제_응답 = given.when()
+                .delete(location)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(즐겨찾기_삭제_응답.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    private ExtractableResponse<Response> 즐겨찾기_추가_요청(String accessToken, Long source, Long target) {
         Map<String, String> params = new HashMap<>();
         params.put("source", source + "");
         params.put("target", target + "");
 
-        // when
-        return RestAssured.given().log().all()
+        var given = RestAssured.given().log().all()
                 .body(params)
-                .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        if (accessToken != null) {
+            given = given.auth().oauth2(accessToken);
+        }
+
+        // when
+        return given
                 .when()
                 .post("/favorites")
                 .then().log().all()

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -86,6 +86,29 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
         });
     }
 
+    /**
+     * GIVEN 로그인한 회원이 즐겨찾기를 하고 <br>
+     * WHEN 즐겨찾기를 삭제하는 경우 <br>
+     * THEN 즐겨찾기가 삭제된다 <br>
+     */
+    @DisplayName("즐겨찾기 삭제")
+    @Test
+    void deleteFavorite() {
+        // given
+        즐겨찾기_추가_요청(강남역, 양재역);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/favorites")
+                .then().log().all()
+                .extract();
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
     private ExtractableResponse<Response> 즐겨찾기_추가_요청(Long source, Long target) {
         Map<String, String> params = new HashMap<>();
         params.put("source", source + "");

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -94,14 +94,15 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteFavorite() {
         // given
-        즐겨찾기_추가_요청(강남역, 양재역);
+        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(강남역, 양재역);
+        String location = 즐겨찾기_추가_응답.header("location");
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .delete("/favorites")
+                .delete(location)
                 .then().log().all()
                 .extract();
         // then

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -15,11 +15,14 @@ import java.util.Map;
 import static nextstep.subway.acceptance.MemberSteps.*;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class FavoriteAcceptanceTest extends AcceptanceTest {
     private Long 강남역;
     private Long 양재역;
-    
+    private Long 양재시민의숲역;
+    private Long 청계산입구역;
+
     private String accessToken;
 
     /**
@@ -32,6 +35,8 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
 
         강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
         양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+        양재시민의숲역 = 지하철역_생성_요청("양재시민의숲역").jsonPath().getLong("id");
+        청계산입구역 = 지하철역_생성_요청("청계산입구역").jsonPath().getLong("id");
 
         회원_생성_요청("bactoria@gmail.com", "qwe123", 20);
         var 베어러_인증_로그인_응답 = 베어러_인증_로그인_요청("bactoria@gmail.com", "qwe123");
@@ -45,13 +50,49 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
     @DisplayName("즐겨찾기 추가")
     @Test
     void addFavorite() {
+        // when
+        var 즐겨찾기_추가_응답 = 즐겨찾기_추가_요청(강남역, 양재역);
+
+        // then
+        assertThat(즐겨찾기_추가_응답.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    /**
+     * GIVEN 로그인한 회원이 즐겨찾기를 2번 하고
+     * WHEN 로그인한 회원이 즐겨찾기 조회하는 경우 <br>
+     * THEN 2개의 즐겨찾기 목록이 조회된다 <br>
+     */
+    @DisplayName("즐겨찾기 조회")
+    @Test
+    void readFavorite() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("source", 강남역 + "");
-        params.put("target", 양재역 + "");
+        즐겨찾기_추가_요청(강남역, 양재역);
+        즐겨찾기_추가_요청(양재시민의숲역, 청계산입구역);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/favorites")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(() -> {
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+            assertThat(response.body().jsonPath().getList("source.id", Long.class)).containsExactly(강남역, 양재시민의숲역);
+            assertThat(response.body().jsonPath().getList("target.id", Long.class)).containsExactly(양재역, 청계산입구역);
+        });
+    }
+
+    private ExtractableResponse<Response> 즐겨찾기_추가_요청(Long source, Long target) {
+        Map<String, String> params = new HashMap<>();
+        params.put("source", source + "");
+        params.put("target", target + "");
+
+        // when
+        return RestAssured.given().log().all()
                 .body(params)
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -59,9 +100,5 @@ class FavoriteAcceptanceTest extends AcceptanceTest {
                 .post("/favorites")
                 .then().log().all()
                 .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
-
 }

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,67 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.subway.acceptance.MemberSteps.*;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FavoriteAcceptanceTest extends AcceptanceTest {
+    private Long 강남역;
+    private Long 양재역;
+    
+    private String accessToken;
+
+    /**
+     * GIVEN 지하철 역을 두개 생성하고
+     * GIVEN 회원가입 후 로그인하고
+     */
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+
+        회원_생성_요청("bactoria@gmail.com", "qwe123", 20);
+        var 베어러_인증_로그인_응답 = 베어러_인증_로그인_요청("bactoria@gmail.com", "qwe123");
+        accessToken = Access_Token을_가져온다(베어러_인증_로그인_응답);
+    }
+
+    /**
+     * WHEN 로그인한 회원이 출발역과 도착역을 즐겨찾기 하는 경우 <br>
+     * THEN 즐겨찾기가 추가된다 <br>
+     */
+    @DisplayName("즐겨찾기 추가")
+    @Test
+    void addFavorite() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("source", 강남역 + "");
+        params.put("target", 양재역 + "");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/favorites")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -1,0 +1,94 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class FavoriteSteps {
+    public static ExtractableResponse<Response> 즐겨찾기_추가_요청(String accessToken, Long source, Long target) {
+        Map<String, String> params = new HashMap<>();
+        params.put("source", source + "");
+        params.put("target", target + "");
+
+        var given = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        if (accessToken != null) {
+            given = given.auth().oauth2(accessToken);
+        }
+
+        // when
+        return given
+                .when()
+                .post("/favorites")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 즐겨찾기_추가됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    public static void 인증_예외_발생함(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    public static void 권한_예외_발생함(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
+    public static void 찾을_수_없는_예외_발생함(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_조회_요청(String accessToken) {
+        var given = RestAssured.given().log().all();
+
+        if (accessToken != null) {
+            given.auth().oauth2(accessToken);
+        }
+
+        return given
+                .when()
+                .get("/favorites")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 즐겨찾기_조회됨(ExtractableResponse<Response> response, List<Long> sourceIds, List<Long> targetIds) {
+        assertAll(() -> {
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.body().jsonPath().getList("source.id", Long.class)).containsExactlyElementsOf(sourceIds);
+            assertThat(response.body().jsonPath().getList("target.id", Long.class)).containsExactlyElementsOf(targetIds);
+        });
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_삭제_요청(String accessToken, String location) {
+        var given = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        if (accessToken != null) {
+            given.auth().oauth2(accessToken);
+        }
+
+        return given
+                .when()
+                .delete(location)
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/src/test/java/nextstep/subway/domain/FavoriteTest.java
+++ b/src/test/java/nextstep/subway/domain/FavoriteTest.java
@@ -1,0 +1,23 @@
+package nextstep.subway.domain;
+
+import nextstep.subway.applicaion.exceptions.CanNotDeleteFavoriteException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FavoriteTest {
+
+    @Test
+    void 즐겨찾기_삭제_시_본인의_즐겨찾기가_아닌_경우_예외가_발생한다() {
+        // given
+        var source = new Station();
+        var target = new Station();
+        var 즐겨찾기_추가한_회원_아이디 = 1L;
+        var 다른_회원_아이디 = 2L;
+
+        Favorite favorite = new Favorite(즐겨찾기_추가한_회원_아이디, source, target);
+
+        // when then
+        assertThatThrownBy(() -> favorite.delete(다른_회원_아이디)).isInstanceOf(CanNotDeleteFavoriteException.class);
+    }
+}

--- a/src/test/java/nextstep/subway/domain/FavoriteTest.java
+++ b/src/test/java/nextstep/subway/domain/FavoriteTest.java
@@ -1,6 +1,6 @@
 package nextstep.subway.domain;
 
-import nextstep.subway.applicaion.exceptions.CanNotDeleteFavoriteException;
+import nextstep.subway.domain.exceptions.CanNotDeleteFavoriteException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
안녕하세요! 😊 

미션 마지막날에 Step3 미션을 제출하게 되었네요!

즐겨찾기 기능 리뷰 요청드려요

<br>

### 참고

[🚀 3단계 - 즐겨찾기 기능 구현 - nextstep](https://edu.nextstep.camp/s/hAciHKm5/ls/WjZ0iaoi) 에 권한이 없는 경우 401 을 응답하라고 되어있는데요.

<img width="626" alt="CleanShot 2023-03-02 at 02 08 10@2x" src="https://user-images.githubusercontent.com/25674959/222211482-fc67fdd6-4bf2-4fcf-b93d-d1edd76ba02a.png">

즐겨찾기 삭제 시 삭제 권한이 없는 유저인 경우 403 응답이 더 적합한 것 같아, 아래와 같이 구현하였습니다.

- 인증토큰이 누락되었거나 / 인증토큰이 유효하지 않은 경우: `401 Unauthorized`
- 즐겨찾기 삭제 시 권한이 없는 유저인 경우: `403 Forbidden`

 참고 부탁드려요!