### PR TITLE
[인수 테스트와 인증] 3단계 - 즐겨찾기 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,165 @@ host: localhost:8080
     - member 가 존재하지 않으면 새로운 멤버를 우리 서버에 등록한다.
       - 해당 멤버의 토큰을 발급한다.
     - member 가 존재하면 해당 멤버의 토큰을 발급한다.
+
+# 3단계 - 즐겨찾기 기능 구현
+## 요구사항
+### 기능 요구사항
+- `요구사항 설명`에서 제공되는 추가된 요구사항을 기반으로 **즐겨 찾기 기능**을 리팩터링하세요.
+- 추가된 요구사항을 정의한 **인수 조건**을 도출하세요.
+- 인수 조건을 검증하는 **인수 테스트**를 작성하세요.
+- 예외 케이스에 대한 검증도 포함하세요.
+  - 로그인이 필요한 API 요청 시 유효하지 않은 경우 401 응답 내려주기
+### 프로그래밍 요구사항
+- **인수 테스트 주도 개발 프로세스**에 맞춰서 기능을 구현하세요.
+  - `요구사항 설명`을 참고하여 인수 조건을 정의
+  - 인수 조건을 검증하는 인수 테스트 작성
+  - 인수 테스트를 충족하는 기능 구현
+- 인수 조건은 인수 테스트 메서드 상단에 주석으로 작성하세요.
+  - 뼈대 코드의 인수 테스트를 참고
+- `인수 테스트 이후 기능 구현은 TDD로 진행하세요.`
+  - 도메인 레이어 테스트는 필수
+  - 서비스 레이어 테스트는 선택
+
+## 요구사항 설명
+### Request / Response
+#### 생성
+```http request
+POST /favorites HTTP/1.1
+authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ7XCJpZFwiOjEsXCJlbWFpbFwiOlwiZW1haWxAZW1haWwuY29tXCIsXCJwYXNzd29yZFwiOlwicGFzc3dvcmRcIixcImFnZVwiOjIwLFwicHJpbmNpcGFsXCI6XCJlbWFpbEBlbWFpbC5jb21cIixcImNyZWRlbnRpYWxzXCI6XCJwYXNzd29yZFwifSIsImlhdCI6MTYxNjQyMzI1NywiZXhwIjoxNjE2NDI2ODU3fQ.7PU1ocohHf-5ro78-zJhgjP2nCg6xnOzvArFME5vY-Y
+accept: */*
+content-type: application/json; charset=UTF-8
+content-length: 27
+host: localhost:60443
+connection: Keep-Alive
+user-agent: Apache-HttpClient/4.5.13 (Java/1.8.0_252)
+accept-encoding: gzip,deflate
+
+{
+    "source": "1",
+    "target": "3"
+}
+```
+```http request
+HTTP/1.1 201 Created
+Keep-Alive: timeout=60
+Connection: keep-alive
+Content-Length: 0
+Date: Mon, 22 Mar 2021 14:27:37 GMT
+Location: /favorites/1
+```
+
+#### 조회
+```http request
+GET /favorites HTTP/1.1
+authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ7XCJpZFwiOjEsXCJlbWFpbFwiOlwiZW1haWxAZW1haWwuY29tXCIsXCJwYXNzd29yZFwiOlwicGFzc3dvcmRcIixcImFnZVwiOjIwLFwicHJpbmNpcGFsXCI6XCJlbWFpbEBlbWFpbC5jb21cIixcImNyZWRlbnRpYWxzXCI6XCJwYXNzd29yZFwifSIsImlhdCI6MTYxNjQyMzI1NywiZXhwIjoxNjE2NDI2ODU3fQ.7PU1ocohHf-5ro78-zJhgjP2nCg6xnOzvArFME5vY-Y
+accept: application/json
+host: localhost:60443
+connection: Keep-Alive
+user-agent: Apache-HttpClient/4.5.13 (Java/1.8.0_252)
+accept-encoding: gzip,deflate
+```
+
+```http request
+HTTP/1.1 200 
+Content-Type: application/json
+Transfer-Encoding: chunked
+Date: Mon, 22 Mar 2021 14:27:37 GMT
+Keep-Alive: timeout=60
+Connection: keep-alive
+
+[
+    {
+        "id": 1,
+        "source": {
+            "id": 1,
+            "name": "교대역"
+        },
+        "target": {
+            "id": 3,
+            "name": "양재역"
+        }
+    }
+]
+```
+
+#### 삭제
+```http request
+DELETE /favorites/1 HTTP/1.1
+authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ7XCJpZFwiOjEsXCJlbWFpbFwiOlwiZW1haWxAZW1haWwuY29tXCIsXCJwYXNzd29yZFwiOlwicGFzc3dvcmRcIixcImFnZVwiOjIwLFwicHJpbmNpcGFsXCI6XCJlbWFpbEBlbWFpbC5jb21cIixcImNyZWRlbnRpYWxzXCI6XCJwYXNzd29yZFwifSIsImlhdCI6MTYxNjQyMzI1NywiZXhwIjoxNjE2NDI2ODU3fQ.7PU1ocohHf-5ro78-zJhgjP2nCg6xnOzvArFME5vY-Y
+accept: */*
+host: localhost:60443
+connection: Keep-Alive
+user-agent: Apache-HttpClient/4.5.13 (Java/1.8.0_252)
+accept-encoding: gzip,deflate
+```
+```http request
+HTTP/1.1 204 No Content
+Keep-Alive: timeout=60
+Connection: keep-alive
+Date: Mon, 22 Mar 2021 14:27:37 GMT
+```
+
+### 권한이 없는 경우 401 Unauthorized 응답
+- 내 정보 관리 / 즐겨 찾기 기능은 로그인 된 상태에서만 가능
+- 비로그인이거나 유효하지 않을 경우 401 Unauthorized 응답
+
+## 요구사항 기반 시나리오
+```
+ 고속터미널역 --- *7호선* --- 강남구청역
+ 
+ 교대역    --- *2호선*  ---  강남역
+   |                        |
+ *3호선*                   *신분당선*
+   |                        |
+ 남부터미널역  --- *3호선* ---  양재
+```
+- 즐겨 찾기 기능을 위한 초기 데이터 셋팅
+  - 고속터미널역 - 강남구청역 (7호선) 이 포함된 노선을 등록한다.
+  - 교대역 - 강남역 (2호선) 이 포함된 노선을 등록한다.
+  - 강남역 - 양재역 (신분당선) 이 포함된 노선을 등록한다.
+  - 교대역 - 남부터미널역 (3호선) 이 포함된 노선을 등록한다.
+  - 남부터미널역 - 양재역 (3호선) 이 포함된 노선을 등록한다.
+
+- 즐겨찾기 생성 인수 테스트
+  - 회원가입된 사용자로 로그인 한다.
+  - 유효한 토큰과 함께 교대역 - 양재역을 즐겨찾기로 생성한다.
+  - 교대역 - 양재역이 즐겨찾기로 생성된다.
+
+- 즐겨찾기 생성 예외 인수 테스트
+  - 회원가입된 사용자로 로그인 한다.
+  - 유효한 토큰과 함께 고속터미널역 - 양재역을 즐겨찾기로 생성한다.
+  - 고속터미널역에서 양재역으로 갈 수 있는 경로가 존재하지 않으므로 즐겨찾기로 생성할 수 없다.
+
+- 즐겨찾기 목록 조회 인수 테스트
+  - 회원가입된 사용자로 로그인 한다.
+  - 유효한 토큰과 함께 교대역 - 양재역을 즐겨찾기로 생성한다.
+  - 유효한 토큰과 함께 강남역 - 남부터미널역을 즐겨찾기로 생성한다.
+  - 유효한 토큰과 함께 즐겨찾기 목록을 조회한다.
+  - 해당 사용자의 즐겨찾기 목록이 조회된다.
+
+- 즐겨찾기 삭제 인수 테스트
+  - 회원가입된 사용자로 로그인 한다.
+  - 유효한 토큰과 함께 교대역 - 양재역을 즐겨찾기로 생성한다.
+  - 교대역 - 양재역 즐겨찾기 삭제 요청한다.
+  - 해당 사용자의 교대역 - 양재역 즐겨찾기가 삭제된다.
+
+- 두 사용자의 즐겨찾기 목록 조회 인수 테스트
+  - 회원가입된 사용자1 로 로그인 한다.
+  - 사용자 1의 유효한 토큰과 함께 교대역 - 양재역을 즐겨찾기로 생성한다.
+  - 회원가입된 사용자2 로 로그인 한다.
+  - 사용자 2의 유효한 토큰과 함께 강남역 - 남부터미널역을 즐겨찾기로 생성한다.
+  - 사용자 2의 즐겨찾기 목록을 조회한다.
+  - 강남역 - 남부터미널역 즐겨찾기가 조회되고, 교대역 - 양재역 즐겨찾기는 사용자 1의 즐겨찾기이므로 조회되지 않는다.
+
+- 다른 사용자의 즐겨찾기 삭제 예외 인수 테스트
+  - 회원가입된 사용자1 로 로그인 한다.
+  - 사용자 1의 유효한 토큰과 함께 교대역 - 양재역을 즐겨찾기로 생성한다.
+  - 회원가입된 사용자2 로 로그인 한다.
+  - 사용자 2의 유효한 토큰과 함께 강남역 - 남부터미널역을 즐겨찾기로 생성한다.
+  - 사용자 2가 교대역 - 양재역 즐겨찾기 삭제 요청한다.
+  - 교대역 - 양재역 즐겨찾기는 사용자 1의 즐겨찾기이므로 삭제할 수 없다.
+
+- 즐겨찾기 관리 기능 유효하지않은 사용자에 대한 예외 인수 테스트
+  - 유효하지 않은 토큰으로 즐겨찾기 생성, 목록 조회, 삭제 요청한다.
+  - 예외가 발생한다.

--- a/src/main/java/nextstep/DataLoader.java
+++ b/src/main/java/nextstep/DataLoader.java
@@ -1,9 +1,0 @@
-package nextstep;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public class DataLoader {
-    public void loadData() {
-    }
-}

--- a/src/main/java/nextstep/auth/application/AuthService.java
+++ b/src/main/java/nextstep/auth/application/AuthService.java
@@ -31,6 +31,7 @@ public class AuthService {
         return new TokenResponse(token);
     }
 
+    @Transactional
     public TokenResponse loginGithub(String code) {
         String accessTokenFromGithub = githubClient.getAccessTokenFromGithub(code);
         String githubEmail = githubClient.getGithubProfileFromGithub(accessTokenFromGithub).getEmail();

--- a/src/main/java/nextstep/auth/application/AuthService.java
+++ b/src/main/java/nextstep/auth/application/AuthService.java
@@ -1,9 +1,9 @@
 package nextstep.auth.application;
 
-import nextstep.auth.exception.AuthenticationException;
+import nextstep.common.exception.AuthenticationException;
 import nextstep.common.config.JwtTokenProvider;
-import nextstep.auth.dto.TokenRequest;
-import nextstep.auth.dto.TokenResponse;
+import nextstep.auth.application.dto.TokenRequest;
+import nextstep.auth.application.dto.TokenResponse;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/nextstep/auth/application/AuthService.java
+++ b/src/main/java/nextstep/auth/application/AuthService.java
@@ -35,13 +35,13 @@ public class AuthService {
         String accessTokenFromGithub = githubClient.getAccessTokenFromGithub(code);
         String githubEmail = githubClient.getGithubProfileFromGithub(accessTokenFromGithub).getEmail();
 
-        Member member = findMemberOrElseGet(githubEmail);
+        Member member = findMemberOrCreateMember(githubEmail);
 
         String token = jwtTokenProvider.createToken(member.getEmail(), member.getRoles());
         return new TokenResponse(token);
     }
 
-    private Member findMemberOrElseGet(String githubEmail) {
+    private Member findMemberOrCreateMember(String githubEmail) {
         return memberRepository.findByEmail(githubEmail)
                 .orElseGet(() -> memberRepository.save(new Member(githubEmail)));
     }

--- a/src/main/java/nextstep/auth/application/GithubClient.java
+++ b/src/main/java/nextstep/auth/application/GithubClient.java
@@ -1,6 +1,6 @@
 package nextstep.auth.application;
 
-import nextstep.auth.dto.GithubProfileResponse;
+import nextstep.auth.application.dto.GithubProfileResponse;
 
 public interface GithubClient {
     String getAccessTokenFromGithub(String code);

--- a/src/main/java/nextstep/auth/application/GithubClientImpl.java
+++ b/src/main/java/nextstep/auth/application/GithubClientImpl.java
@@ -1,9 +1,9 @@
 package nextstep.auth.application;
 
-import nextstep.auth.dto.GithubAccessTokenRequest;
-import nextstep.auth.dto.GithubAccessTokenResponse;
-import nextstep.auth.dto.GithubProfileResponse;
-import nextstep.auth.exception.AuthenticationException;
+import nextstep.auth.application.dto.GithubAccessTokenRequest;
+import nextstep.auth.application.dto.GithubAccessTokenResponse;
+import nextstep.auth.application.dto.GithubProfileResponse;
+import nextstep.common.exception.AuthenticationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/nextstep/auth/application/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/nextstep/auth/application/dto/GithubAccessTokenRequest.java
@@ -1,4 +1,4 @@
-package nextstep.auth.dto;
+package nextstep.auth.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/nextstep/auth/application/dto/GithubAccessTokenResponse.java
+++ b/src/main/java/nextstep/auth/application/dto/GithubAccessTokenResponse.java
@@ -1,4 +1,4 @@
-package nextstep.auth.dto;
+package nextstep.auth.application.dto;
 
 public class GithubAccessTokenResponse {
     private String accessToken;

--- a/src/main/java/nextstep/auth/application/dto/GithubLoginRequest.java
+++ b/src/main/java/nextstep/auth/application/dto/GithubLoginRequest.java
@@ -1,4 +1,4 @@
-package nextstep.auth.dto;
+package nextstep.auth.application.dto;
 
 public class GithubLoginRequest {
     private String code;

--- a/src/main/java/nextstep/auth/application/dto/GithubProfileResponse.java
+++ b/src/main/java/nextstep/auth/application/dto/GithubProfileResponse.java
@@ -1,4 +1,4 @@
-package nextstep.auth.dto;
+package nextstep.auth.application.dto;
 
 public class GithubProfileResponse {
     private String email;

--- a/src/main/java/nextstep/auth/application/dto/TokenRequest.java
+++ b/src/main/java/nextstep/auth/application/dto/TokenRequest.java
@@ -1,4 +1,4 @@
-package nextstep.auth.dto;
+package nextstep.auth.application.dto;
 
 public class TokenRequest {
     private String email;

--- a/src/main/java/nextstep/auth/application/dto/TokenResponse.java
+++ b/src/main/java/nextstep/auth/application/dto/TokenResponse.java
@@ -1,4 +1,4 @@
-package nextstep.auth.dto;
+package nextstep.auth.application.dto;
 
 public class TokenResponse {
     private String accessToken;

--- a/src/main/java/nextstep/auth/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/nextstep/auth/dto/GithubAccessTokenRequest.java
@@ -1,8 +1,12 @@
 package nextstep.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class GithubAccessTokenRequest {
     private String code;
+    @JsonProperty("client_id")
     private String clientId;
+    @JsonProperty("client_secret")
     private String clientSecret;
 
     public GithubAccessTokenRequest(String code, String clientId, String clientSecret) {

--- a/src/main/java/nextstep/auth/ui/AppMemberArgumentResolver.java
+++ b/src/main/java/nextstep/auth/ui/AppMemberArgumentResolver.java
@@ -1,6 +1,6 @@
 package nextstep.auth.ui;
 
-import nextstep.auth.exception.AuthorizationException;
+import nextstep.common.exception.AuthorizationException;
 import nextstep.common.config.JwtTokenProvider;
 import nextstep.auth.domain.AppMember;
 import nextstep.auth.domain.AuthenticationMember;

--- a/src/main/java/nextstep/auth/ui/AuthController.java
+++ b/src/main/java/nextstep/auth/ui/AuthController.java
@@ -1,9 +1,9 @@
 package nextstep.auth.ui;
 
 import nextstep.auth.application.AuthService;
-import nextstep.auth.dto.GithubLoginRequest;
-import nextstep.auth.dto.TokenRequest;
-import nextstep.auth.dto.TokenResponse;
+import nextstep.auth.application.dto.GithubLoginRequest;
+import nextstep.auth.application.dto.TokenRequest;
+import nextstep.auth.application.dto.TokenResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/nextstep/common/exception/AuthenticationException.java
+++ b/src/main/java/nextstep/common/exception/AuthenticationException.java
@@ -1,4 +1,4 @@
-package nextstep.auth.exception;
+package nextstep.common.exception;
 
 public class AuthenticationException extends RuntimeException {
     private final ErrorCode errorCode;

--- a/src/main/java/nextstep/common/exception/AuthorizationException.java
+++ b/src/main/java/nextstep/common/exception/AuthorizationException.java
@@ -1,4 +1,4 @@
-package nextstep.auth.exception;
+package nextstep.common.exception;
 
 public class AuthorizationException extends RuntimeException {
     private final ErrorCode errorCode;

--- a/src/main/java/nextstep/common/exception/CanNotDeleteFavoriteException.java
+++ b/src/main/java/nextstep/common/exception/CanNotDeleteFavoriteException.java
@@ -1,0 +1,14 @@
+package nextstep.common.exception;
+
+public class CanNotDeleteFavoriteException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CanNotDeleteFavoriteException() {
+        super(ErrorCode.CAN_NOT_DELETE_FAVORITE.getMessage());
+        this.errorCode = ErrorCode.CAN_NOT_DELETE_FAVORITE;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/nextstep/common/exception/ErrorCode.java
+++ b/src/main/java/nextstep/common/exception/ErrorCode.java
@@ -4,6 +4,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자 입니다."),
+    NOT_FOUND_FAVORITE(HttpStatus.BAD_REQUEST, "존재하지 않는 즐겨찾기 입니다."),
+    CAN_NOT_DELETE_FAVORITE(HttpStatus.BAD_REQUEST, "다른 사용자의 즐겨찾기는 삭제할 수 없습니다."),
+    NO_PATH(HttpStatus.BAD_REQUEST, "두 역은 연결된 경로가 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자 입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근할 수 없는 사용자입니다.");
 

--- a/src/main/java/nextstep/common/exception/ErrorCode.java
+++ b/src/main/java/nextstep/common/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package nextstep.auth.exception;
+package nextstep.common.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/nextstep/common/exception/ErrorResponse.java
+++ b/src/main/java/nextstep/common/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package nextstep.auth.exception;
+package nextstep.common.exception;
 
 public class ErrorResponse {
     private final String code;

--- a/src/main/java/nextstep/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/common/exception/GlobalExceptionHandler.java
@@ -8,21 +8,30 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
     @ExceptionHandler(AuthorizationException.class)
     protected ResponseEntity<ErrorResponse> handleAuthorizationException(AuthorizationException e) {
-        final ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(makeErrorResponse(errorCode));
+        return getErrorResponseResponseEntity(e.getErrorCode());
     }
 
     @ExceptionHandler(AuthenticationException.class)
     protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
-        final ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(makeErrorResponse(errorCode));
+        return getErrorResponseResponseEntity(e.getErrorCode());
     }
 
     @ExceptionHandler(NotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
-        final ErrorCode errorCode = e.getErrorCode();
+        return getErrorResponseResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(NoPathException.class)
+    protected ResponseEntity<ErrorResponse> handleNoPathException(NoPathException e) {
+        return getErrorResponseResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(CanNotDeleteFavoriteException.class)
+    protected ResponseEntity<ErrorResponse> handleCanNotDeleteFavoriteException(CanNotDeleteFavoriteException e) {
+        return getErrorResponseResponseEntity(e.getErrorCode());
+    }
+
+    private ResponseEntity<ErrorResponse> getErrorResponseResponseEntity(ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(makeErrorResponse(errorCode));
     }

--- a/src/main/java/nextstep/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package nextstep.auth.exception;
+package nextstep.common.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/nextstep/common/exception/NoPathException.java
+++ b/src/main/java/nextstep/common/exception/NoPathException.java
@@ -1,0 +1,13 @@
+package nextstep.common.exception;
+
+public class NoPathException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public NoPathException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/nextstep/common/exception/NotFoundException.java
+++ b/src/main/java/nextstep/common/exception/NotFoundException.java
@@ -1,6 +1,6 @@
-package nextstep.auth.exception;
+package nextstep.common.exception;
 
-public class NotFoundException extends RuntimeException{
+public class NotFoundException extends RuntimeException {
     private final ErrorCode errorCode;
 
     public NotFoundException(ErrorCode errorCode) {

--- a/src/main/java/nextstep/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/favorite/application/FavoriteService.java
@@ -1,0 +1,68 @@
+package nextstep.favorite.application;
+
+import nextstep.common.exception.CanNotDeleteFavoriteException;
+import nextstep.common.exception.ErrorCode;
+import nextstep.common.exception.NotFoundException;
+import nextstep.favorite.application.dto.FavoriteRequest;
+import nextstep.favorite.application.dto.FavoriteResponse;
+import nextstep.favorite.domain.Favorite;
+import nextstep.favorite.domain.FavoriteRepository;
+import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Station;
+import nextstep.subway.domain.SubwayMap;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class FavoriteService {
+    private final FavoriteRepository favoriteRepository;
+    private final StationService stationService;
+    private final LineService lineService;
+
+    public FavoriteService(FavoriteRepository favoriteRepository, StationService stationService, LineService lineService) {
+        this.favoriteRepository = favoriteRepository;
+        this.stationService = stationService;
+        this.lineService = lineService;
+    }
+
+    @Transactional
+    public Long saveFavorite(Long memberId, FavoriteRequest favoriteRequest) {
+        Station sourceStation = stationService.findById(favoriteRequest.getSource());
+        Station targetStation = stationService.findById(favoriteRequest.getTarget());
+
+        validateStationPath(sourceStation, targetStation);
+
+        return favoriteRepository.save(new Favorite(memberId, sourceStation, targetStation)).getId();
+    }
+
+    private void validateStationPath(Station sourceStation, Station targetStation) {
+        List<Line> lines = lineService.findLines();
+        SubwayMap subwayMap = new SubwayMap(lines);
+        subwayMap.findPath(sourceStation, targetStation);
+    }
+
+    public List<FavoriteResponse> findFavorites(Long memberId) {
+        return favoriteRepository.findAllByMemberId(memberId).stream()
+                .map(FavoriteResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteFavorite(Long favoriteId, Long memberId) {
+        Favorite favorite = findById(favoriteId);
+        if (!favorite.isCreatedBy(memberId)) {
+            throw new CanNotDeleteFavoriteException();
+        }
+        favoriteRepository.delete(favorite);
+    }
+
+    private Favorite findById(Long id) {
+        return favoriteRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_FAVORITE));
+    }
+}

--- a/src/main/java/nextstep/favorite/application/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/favorite/application/dto/FavoriteRequest.java
@@ -1,0 +1,14 @@
+package nextstep.favorite.application.dto;
+
+public class FavoriteRequest {
+    private Long source;
+    private Long target;
+
+    public Long getSource() {
+        return source;
+    }
+
+    public Long getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/favorite/application/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/favorite/application/dto/FavoriteResponse.java
@@ -1,0 +1,32 @@
+package nextstep.favorite.application.dto;
+
+import nextstep.favorite.domain.Favorite;
+import nextstep.subway.applicaion.dto.StationResponse;
+
+public class FavoriteResponse {
+    private Long id;
+    private StationResponse source;
+    private StationResponse target;
+
+    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+        this.id = id;
+        this.source = source;
+        this.target = target;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StationResponse getSource() {
+        return source;
+    }
+
+    public StationResponse getTarget() {
+        return target;
+    }
+
+    public static FavoriteResponse of(Favorite favorite) {
+        return new FavoriteResponse(favorite.getId(), StationResponse.of(favorite.getSourceStation()), StationResponse.of(favorite.getTargetStation()));
+    }
+}

--- a/src/main/java/nextstep/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/favorite/domain/Favorite.java
@@ -1,0 +1,55 @@
+package nextstep.favorite.domain;
+
+import nextstep.subway.domain.Station;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_id")
+    private Station sourceStation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id")
+    private Station targetStation;
+
+    protected Favorite() {
+    }
+
+    public Favorite(Long memberId, Station sourceStation, Station targetStation) {
+        this.memberId = memberId;
+        this.sourceStation = sourceStation;
+        this.targetStation = targetStation;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Station getSourceStation() {
+        return sourceStation;
+    }
+
+    public Station getTargetStation() {
+        return targetStation;
+    }
+
+    public boolean isCreatedBy(Long memberId) {
+        return this.memberId.equals(memberId);
+    }
+}

--- a/src/main/java/nextstep/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/favorite/domain/FavoriteRepository.java
@@ -1,0 +1,9 @@
+package nextstep.favorite.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    List<Favorite> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/nextstep/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/favorite/ui/FavoriteController.java
@@ -1,0 +1,44 @@
+package nextstep.favorite.ui;
+
+import nextstep.auth.domain.AppMember;
+import nextstep.auth.domain.AuthenticationMember;
+import nextstep.favorite.application.FavoriteService;
+import nextstep.favorite.application.dto.FavoriteRequest;
+import nextstep.favorite.application.dto.FavoriteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+public class FavoriteController {
+    private final FavoriteService favoriteService;
+
+    public FavoriteController(FavoriteService favoriteService) {
+        this.favoriteService = favoriteService;
+    }
+
+    @PostMapping("/favorites")
+    public ResponseEntity<Void> createFavorite(@AuthenticationMember AppMember appMember, @RequestBody FavoriteRequest favoriteRequest) {
+        Long favoriteId = favoriteService.saveFavorite(appMember.getId(), favoriteRequest);
+        return ResponseEntity.created(URI.create("/favorites/" + favoriteId)).build();
+    }
+
+    @GetMapping("/favorites")
+    public ResponseEntity<List<FavoriteResponse>> showFavorites(@AuthenticationMember AppMember appMember) {
+        List<FavoriteResponse> favoriteResponses = favoriteService.findFavorites(appMember.getId());
+        return ResponseEntity.ok().body(favoriteResponses);
+    }
+
+    @DeleteMapping("/favorites/{id}")
+    public ResponseEntity<Void> deleteFavorite(@AuthenticationMember AppMember appMember, @PathVariable Long id) {
+        favoriteService.deleteFavorite(id, appMember.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/nextstep/member/application/MemberService.java
+++ b/src/main/java/nextstep/member/application/MemberService.java
@@ -1,7 +1,7 @@
 package nextstep.member.application;
 
-import nextstep.auth.exception.ErrorCode;
-import nextstep.auth.exception.NotFoundException;
+import nextstep.common.exception.ErrorCode;
+import nextstep.common.exception.NotFoundException;
 import nextstep.member.application.dto.MemberRequest;
 import nextstep.member.application.dto.MemberResponse;
 import nextstep.member.domain.Member;

--- a/src/main/java/nextstep/member/domain/Member.java
+++ b/src/main/java/nextstep/member/domain/Member.java
@@ -1,6 +1,6 @@
 package nextstep.member.domain;
 
-import nextstep.auth.exception.AuthenticationException;
+import nextstep.common.exception.AuthenticationException;
 
 import javax.persistence.*;
 import java.util.List;

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -38,6 +38,10 @@ public class Line {
         return sections.getSections();
     }
 
+    public List<Section> getOppositeSections() {
+        return sections.getOppositeSections();
+    }
+
     public void update(String name, String color) {
         if (name != null) {
             this.name = name;

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -25,6 +25,12 @@ public class Sections {
         return sections;
     }
 
+    public List<Section> getOppositeSections() {
+        return sections.stream()
+                .map(section -> new Section(section.getLine(), section.getDownStation(), section.getUpStation(), section.getDistance()))
+                .collect(Collectors.toList());
+    }
+
     public void add(Section section) {
         if (this.sections.isEmpty()) {
             this.sections.add(section);

--- a/src/main/java/nextstep/subway/domain/SubwayMap.java
+++ b/src/main/java/nextstep/subway/domain/SubwayMap.java
@@ -1,5 +1,7 @@
 package nextstep.subway.domain;
 
+import nextstep.common.exception.ErrorCode;
+import nextstep.common.exception.NoPathException;
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
@@ -34,7 +36,11 @@ public class SubwayMap {
     private static GraphPath<Station, SectionEdge> findShortedPath(Station source, Station target, SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
         // 다익스트라 최단 경로 찾기
         DijkstraShortestPath<Station, SectionEdge> dijkstraShortestPath = new DijkstraShortestPath<>(graph);
-        return dijkstraShortestPath.getPath(source, target);
+        GraphPath<Station, SectionEdge> result = dijkstraShortestPath.getPath(source, target);
+        if (result == null) {
+            throw new NoPathException(ErrorCode.NO_PATH);
+        }
+        return result;
     }
 
     private void addEdge(SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {

--- a/src/main/java/nextstep/subway/domain/SubwayMap.java
+++ b/src/main/java/nextstep/subway/domain/SubwayMap.java
@@ -5,7 +5,9 @@ import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SubwayMap {
     private List<Line> lines;
@@ -17,40 +19,50 @@ public class SubwayMap {
     public Path findPath(Station source, Station target) {
         SimpleDirectedWeightedGraph<Station, SectionEdge> graph = new SimpleDirectedWeightedGraph<>(SectionEdge.class);
 
-        // 지하철 역(정점)을 등록
-        lines.stream()
-                .flatMap(it -> it.getStations().stream())
-                .distinct()
-                .collect(Collectors.toList())
-                .forEach(it -> graph.addVertex(it));
+        addVertex(graph);
+        addEdge(graph);
 
-        // 지하철 역의 연결 정보(간선)을 등록
-        lines.stream()
-                .flatMap(it -> it.getSections().stream())
-                .forEach(it -> {
-                    SectionEdge sectionEdge = SectionEdge.of(it);
-                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
-                    graph.setEdgeWeight(sectionEdge, it.getDistance());
-                });
-
-        // 지하철 역의 연결 정보(간선)을 등록
-        lines.stream()
-                .flatMap(it -> it.getSections().stream())
-                .map(it -> new Section(it.getLine(), it.getDownStation(), it.getUpStation(), it.getDistance()))
-                .forEach(it -> {
-                    SectionEdge sectionEdge = SectionEdge.of(it);
-                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
-                    graph.setEdgeWeight(sectionEdge, it.getDistance());
-                });
-
-        // 다익스트라 최단 경로 찾기
-        DijkstraShortestPath<Station, SectionEdge> dijkstraShortestPath = new DijkstraShortestPath<>(graph);
-        GraphPath<Station, SectionEdge> result = dijkstraShortestPath.getPath(source, target);
+        GraphPath<Station, SectionEdge> result = findShortedPath(source, target, graph);
 
         List<Section> sections = result.getEdgeList().stream()
-                .map(it -> it.getSection())
+                .map(SectionEdge::getSection)
                 .collect(Collectors.toList());
 
         return new Path(new Sections(sections));
+    }
+
+    private static GraphPath<Station, SectionEdge> findShortedPath(Station source, Station target, SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
+        // 다익스트라 최단 경로 찾기
+        DijkstraShortestPath<Station, SectionEdge> dijkstraShortestPath = new DijkstraShortestPath<>(graph);
+        return dijkstraShortestPath.getPath(source, target);
+    }
+
+    private void addEdge(SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
+        // 지하철 역의 연결 정보(간선)을 등록 (역방향 포함)
+        List<Section> sections =
+                Stream.concat(
+                        flatMap(lines, line -> line.getSections().stream()).stream(),
+                        flatMap(lines, line -> line.getOppositeSections().stream()).stream()
+                ).collect(Collectors.toList());
+
+        sections.forEach(section -> addEdge(graph, section));
+    }
+
+    private static void addEdge(SimpleDirectedWeightedGraph<Station, SectionEdge> graph, Section it) {
+        SectionEdge sectionEdge = SectionEdge.of(it);
+        graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
+        graph.setEdgeWeight(sectionEdge, it.getDistance());
+    }
+
+    private void addVertex(SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
+        // 지하철 역(정점)을 등록
+        List<Station> stations = flatMap(lines, line -> line.getStations().stream());
+        stations.forEach(graph::addVertex);
+    }
+
+    private <T, R> List<R> flatMap(List<T> list, Function<T, Stream<R>> function) {
+        return list.stream()
+                .flatMap(function)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/nextstep/AcceptanceTest.java
+++ b/src/test/java/nextstep/AcceptanceTest.java
@@ -1,5 +1,6 @@
 package nextstep;
 
+import nextstep.utils.DataLoader;
 import nextstep.utils.DatabaseCleanup;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,9 +12,12 @@ import org.springframework.test.context.ActiveProfiles;
 public class AcceptanceTest {
     @Autowired
     private DatabaseCleanup databaseCleanup;
+    @Autowired
+    private DataLoader dataLoader;
 
     @BeforeEach
     protected void setUp() {
         databaseCleanup.execute();
+        dataLoader.loadData();
     }
 }

--- a/src/test/java/nextstep/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/auth/acceptance/AuthAcceptanceTest.java
@@ -23,15 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AuthAcceptanceTest extends AcceptanceTest {
     private static final String EMAIL = "admin@email.com";
     private static final String PASSWORD = "password";
-    private static final int AGE = 29;
-
-    // given
-    @BeforeEach
-    protected void setUp() {
-        super.setUp();
-
-        회원_생성_요청(EMAIL, PASSWORD, AGE);
-    }
 
     /**
      * given 회원이 있을 때
@@ -88,7 +79,6 @@ class AuthAcceptanceTest extends AcceptanceTest {
     @ValueSource(strings = {"사용자1", "사용자2", "사용자3", "사용자4"})
     void githubAuthLoginAlreadyMember(FakeGithubResponses fakeGithubResponses) {
         // given
-        회원_생성_요청(fakeGithubResponses.getEmail(), PASSWORD, AGE);
         Map<String, String> params = new HashMap<>();
         params.put("code", fakeGithubResponses.getCode());
 
@@ -105,12 +95,11 @@ class AuthAcceptanceTest extends AcceptanceTest {
      * then 우리 서버의 토큰을 발급받을 수 있다.
      */
     @DisplayName("Github Auth : Github 에서 받은 서버에 등록되지 않은 유저의 권한증서(code)를 이용하여 로그인 요청 하면 액세스 토큰을 받는다.")
-    @ParameterizedTest
-    @ValueSource(strings = {"사용자1", "사용자2", "사용자3", "사용자4"})
-    void githubAuthLoginCreateMember(FakeGithubResponses fakeGithubResponses) {
+    @Test
+    void githubAuthLoginCreateMember() {
         // given
         Map<String, String> params = new HashMap<>();
-        params.put("code", fakeGithubResponses.getCode());
+        params.put("code", FakeGithubResponses.비회원.getCode());
 
         // when
         ExtractableResponse<Response> response = 깃헙_로그인_요청_성공(params);

--- a/src/test/java/nextstep/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/auth/acceptance/AuthAcceptanceTest.java
@@ -104,7 +104,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
      * when Github 로 로그인 요청하면
      * then 우리 서버의 토큰을 발급받을 수 있다.
      */
-    @DisplayName("Github Auth : Github 에서 받은 이미 등록된 유저의 권한증서(code)를 이용하여 로그인 요청 하면 액세스 토큰을 받는다.")
+    @DisplayName("Github Auth : Github 에서 받은 서버에 등록되지 않은 유저의 권한증서(code)를 이용하여 로그인 요청 하면 액세스 토큰을 받는다.")
     @ParameterizedTest
     @ValueSource(strings = {"사용자1", "사용자2", "사용자3", "사용자4"})
     void githubAuthLoginCreateMember(FakeGithubResponses fakeGithubResponses) {

--- a/src/test/java/nextstep/auth/acceptance/fake/FakeGithubClientImpl.java
+++ b/src/test/java/nextstep/auth/acceptance/fake/FakeGithubClientImpl.java
@@ -1,7 +1,7 @@
 package nextstep.auth.acceptance.fake;
 
 import nextstep.auth.application.GithubClient;
-import nextstep.auth.dto.GithubProfileResponse;
+import nextstep.auth.application.dto.GithubProfileResponse;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;

--- a/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
+++ b/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
@@ -1,6 +1,6 @@
 package nextstep.auth.acceptance.fake;
 
-import nextstep.auth.dto.GithubProfileResponse;
+import nextstep.auth.application.dto.GithubProfileResponse;
 import nextstep.auth.exception.AuthenticationException;
 
 import java.util.Arrays;

--- a/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
+++ b/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
@@ -1,7 +1,7 @@
 package nextstep.auth.acceptance.fake;
 
 import nextstep.auth.application.dto.GithubProfileResponse;
-import nextstep.auth.exception.AuthenticationException;
+import nextstep.common.exception.AuthenticationException;
 
 import java.util.Arrays;
 

--- a/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
+++ b/src/test/java/nextstep/auth/acceptance/fake/FakeGithubResponses.java
@@ -9,7 +9,8 @@ public enum FakeGithubResponses {
     사용자1("832ovnq039hfjn", "access_token_1", "email1@email.com"),
     사용자2("mkfo0aFa03m", "access_token_2", "email2@email.com"),
     사용자3("m-a3hnfnoew92", "access_token_3", "email3@email.com"),
-    사용자4("nvci383mciq0oq", "access_token_4", "email4@email.com");
+    사용자4("nvci383mciq0oq", "access_token_4", "email4@email.com"),
+    비회원("abcdefghijk", "access_token_5", "email5@email.com");
 
     private String code;
     private String accessToken;

--- a/src/test/java/nextstep/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,206 @@
+package nextstep.favorite.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.AcceptanceTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static nextstep.favorite.acceptance.FavoriteSteps.권한없음;
+import static nextstep.favorite.acceptance.FavoriteSteps.내_즐겨찾기_목록만_조회됨;
+import static nextstep.favorite.acceptance.FavoriteSteps.다른_사용자의_즐겨찾기_삭제_실패;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_목록_조회_요청;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_목록_조회됨;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_삭제_요청;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_삭제됨;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_생성_실패함;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_생성_요청;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_생성_응답_식별자;
+import static nextstep.favorite.acceptance.FavoriteSteps.즐겨찾기_생성됨;
+import static nextstep.member.acceptance.MemberSteps.베어러_인증_로그인_요청_성공;
+import static nextstep.subway.acceptance.LineSteps.createSectionCreateParams;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_생성_요청;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+
+@DisplayName("즐겨찾기 관련 기능")
+class FavoriteAcceptanceTest extends AcceptanceTest {
+    private static final String EMAIL = "member@email.com";
+    private static final String PASSWORD = "password";
+    private static final int AGE = 29;
+
+    private Long 고속터미널역;
+    private Long 강남구청역;
+    private Long 교대역;
+    private Long 강남역;
+    private Long 양재역;
+    private Long 남부터미널역;
+    private Long 칠호선;
+    private Long 이호선;
+    private Long 신분당선;
+    private Long 삼호선;
+    private String 유효한_토큰;
+    private String 유효하지_않은_토큰;
+
+    /**
+     * 고속터미널역  --- *7호선* ---  강남구청역
+     *
+     * 교대역    --- *2호선* ---   강남역
+     * |                        |
+     * *3호선*                   *신분당선*
+     * |                        |
+     * 남부터미널역  --- *3호선* ---   양재
+     */
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        고속터미널역 = 지하철역_생성_요청("고속터미널역").jsonPath().getLong("id");
+        강남구청역 = 지하철역_생성_요청("강남구청역").jsonPath().getLong("id");
+        교대역 = 지하철역_생성_요청("교대역").jsonPath().getLong("id");
+        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+        남부터미널역 = 지하철역_생성_요청("남부터미널역").jsonPath().getLong("id");
+
+        칠호선 = 지하철_노선_생성_요청("7호선", "dark green", 고속터미널역, 강남구청역, 5);
+        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10);
+        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10);
+        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2);
+
+        지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역, 3));
+
+        유효한_토큰 = 베어러_인증_로그인_요청_성공(EMAIL, PASSWORD).jsonPath().getString("accessToken");
+        유효하지_않은_토큰 = "invalid token";
+    }
+
+    /**
+     * Given 사용자가 로그인 후, 노선과 역, 구간을 등록하고
+     * When 출발역, 도착역, 2가지 역을 선택하여 즐겨찾기 생성 요청하면
+     * Then 두 역에 대한 즐겨찾기가 생성된다.
+     */
+    @DisplayName("즐겨찾기 생성")
+    @Test
+    void createFavorite() {
+        // when
+        ExtractableResponse<Response> 즐겨찾기_생성_요청_응답 = 즐겨찾기_생성_요청(유효한_토큰, 교대역, 양재역);
+
+        // then
+        즐겨찾기_생성됨(즐겨찾기_생성_요청_응답);
+    }
+
+    /**
+     * Given 사용자가 로그인 후, 노선과 역, 구간을 등록하고
+     * When 출발역, 도착역이 연결되지 않은 2가지 역을 선택하여 즐겨찾기 생성 요청하면
+     * Then 두 역에 대한 즐겨찾기를 생성할 수 없다.
+     */
+    @DisplayName("즐겨찾기 생성 예외")
+    @Test
+    void createFavoriteExceptionNotConnect() {
+        // when
+        ExtractableResponse<Response> 즐겨찾기_생성_요청_응답 = 즐겨찾기_생성_요청(유효한_토큰, 고속터미널역, 양재역);
+
+        // then
+        즐겨찾기_생성_실패함(즐겨찾기_생성_요청_응답);
+    }
+
+    /**
+     * Given 사용자가 로그인 후, 노선과 역, 구간을 등록하고, 두 역에 대한 즐겨찾기를 여러번 등록하고
+     * When 내 즐겨찾기 목록을 조회하면
+     * Then 즐겨찾기 목록을 조회할 수 있다.
+     */
+    @DisplayName("즐겨찾기 목록 조회")
+    @Test
+    void getFavorites() {
+        // given
+        Long 교대_양재_즐겨찾기 = 즐겨찾기_생성_응답_식별자(즐겨찾기_생성_요청(유효한_토큰, 교대역, 양재역));
+        Long 강남_남부터미널_즐겨찾기 = 즐겨찾기_생성_응답_식별자(즐겨찾기_생성_요청(유효한_토큰, 강남역, 남부터미널역));
+
+        // when
+        ExtractableResponse<Response> 즐겨찾기_목록_조회_응답 = 즐겨찾기_목록_조회_요청(유효한_토큰);
+
+        // then
+        즐겨찾기_목록_조회됨(교대_양재_즐겨찾기, 강남_남부터미널_즐겨찾기, 즐겨찾기_목록_조회_응답);
+    }
+
+    /**
+     * Given 사용자가 로그인 후, 노선과 역, 구간을 등록하고, 두 역에 대한 즐겨찾기를 생성하고
+     * When 등록한 즐겨찾기를 삭제하면
+     * Then 즐겨찾기가 삭제된다.
+     */
+    @DisplayName("즐겨찾기 삭제")
+    @Test
+    void deleteFavorite() {
+        // given
+        Long 교대_양재_즐겨찾기 = 즐겨찾기_생성_응답_식별자(즐겨찾기_생성_요청(유효한_토큰, 교대역, 양재역));;
+
+        // when
+        ExtractableResponse<Response> 즐겨찾기_삭제_요청_응답 = 즐겨찾기_삭제_요청(유효한_토큰, 교대_양재_즐겨찾기);
+
+        // then
+        ExtractableResponse<Response> 즐겨찾기_목록_조회_요청_응답 = 즐겨찾기_목록_조회_요청(유효한_토큰);
+        즐겨찾기_삭제됨(교대_양재_즐겨찾기, 즐겨찾기_목록_조회_요청_응답, 즐겨찾기_삭제_요청_응답);
+    }
+
+    /**
+     * Given 두 사용자가 로그인 후 서로 다른 즐겨찾기를 등록한 후
+     * When 한 사용자의 즐겨찾기 목록을 조회하면
+     * Then 내가 등록한 즐겨찾기만 조회 가능하고, 다른 사용자의 즐겨찾기 목록은 조회되지 않는다.
+     */
+    @DisplayName("두 사용자 중 자신의 즐겨찾기 목록만 조회")
+    @Test
+    void getFavoritesMine() {
+        // given
+        String 다른_사용자의_유효한_토큰 = 베어러_인증_로그인_요청_성공("admin@email.com", "password").jsonPath().getString("accessToken");
+
+        Long 내_교대_양재_즐겨찾기 = 즐겨찾기_생성_응답_식별자(즐겨찾기_생성_요청(유효한_토큰, 교대역, 양재역));
+        Long 다른_사용자의_강남_남부터미널_즐겨찾기 = 즐겨찾기_생성_응답_식별자(즐겨찾기_생성_요청(다른_사용자의_유효한_토큰, 강남역, 남부터미널역));
+
+        // when
+        ExtractableResponse<Response> 즐겨찾기_목록_조회_응답 = 즐겨찾기_목록_조회_요청(유효한_토큰);
+
+        // then
+        내_즐겨찾기_목록만_조회됨(내_교대_양재_즐겨찾기, 다른_사용자의_강남_남부터미널_즐겨찾기, 즐겨찾기_목록_조회_응답);
+    }
+
+    /**
+     * Given 두 사용자가 로그인 후 서로 다른 즐겨찾기를 등록한 후
+     * When 한 사용자가 다른 사용자의 즐겨찾기를 삭제 요쳥하면
+     * Then 다른 사용자의 즐겨찾기를 삭제할 수 없다.
+     */
+    @DisplayName("다른 사용자의 즐겨찾기 삭제를 할 수 없다.")
+    @Test
+    void doNotDeleteOtherMemberFavorite() {
+        // given
+        String 다른_사용자의_유효한_토큰 = 베어러_인증_로그인_요청_성공("admin@email.com", "password").jsonPath().getString("accessToken");
+
+        즐겨찾기_생성_요청(유효한_토큰, 교대역, 양재역);
+        Long 다른_사용자의_강남_남부터미널_즐겨찾기 = 즐겨찾기_생성_응답_식별자(즐겨찾기_생성_요청(다른_사용자의_유효한_토큰, 강남역, 남부터미널역));
+
+        // when
+        ExtractableResponse<Response> 즐겨찾기_삭제_응답 = 즐겨찾기_삭제_요청(유효한_토큰, 다른_사용자의_강남_남부터미널_즐겨찾기);
+
+        // then
+        다른_사용자의_즐겨찾기_삭제_실패(즐겨찾기_삭제_응답);
+    }
+
+    /**
+     * When 유효하지 않은 사용자가 즐겨찾기를 생성, 조회, 삭제 요청할 경우
+     * Then 모두 예외가 발생한다.
+     */
+    @DisplayName("유효하지 않은 사용자의 즐겨찾기 관리 기능 예외")
+    @Test
+    void favoriteFunctionExceptionNotLogin() {
+        // when & then
+        ExtractableResponse<Response> createResponse = 즐겨찾기_생성_요청(유효하지_않은_토큰, 교대역, 양재역);
+        권한없음(createResponse);
+
+        // when & then
+        ExtractableResponse<Response> getResponse = 즐겨찾기_목록_조회_요청(유효하지_않은_토큰);
+        권한없음(getResponse);
+
+        // when & then
+        ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청(유효하지_않은_토큰, 1L);
+        권한없음(deleteResponse);
+    }
+}

--- a/src/test/java/nextstep/favorite/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/favorite/acceptance/FavoriteSteps.java
@@ -1,0 +1,94 @@
+package nextstep.favorite.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class FavoriteSteps {
+    private static final String FAVORITE_URL = "/favorites ";
+    private static final String LOCATION = "Location";
+
+    public static ExtractableResponse<Response> 즐겨찾기_생성_요청(String accessToken, Long source, Long target) {
+        Map<String, String> params = new HashMap<>();
+        params.put("source", source + "");
+        params.put("target", target + "");
+
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/favorites")
+                .then().log().all().extract();
+
+    }
+
+    public static Long 즐겨찾기_생성_응답_식별자(ExtractableResponse<Response> createResponse) {
+        return Long.parseLong(createResponse.header(LOCATION).substring(FAVORITE_URL.length()));
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_목록_조회_요청(String accessToken) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/favorites")
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_삭제_요청(String accessToken, Long id) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .when().delete("/favorites/{id}", id)
+                .then().log().all().extract();
+    }
+
+    public static void 즐겨찾기_생성됨(ExtractableResponse<Response> 즐겨찾기_생성_요청_응답) {
+        assertThat(즐겨찾기_생성_요청_응답.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    public static void 즐겨찾기_생성_실패함(ExtractableResponse<Response> 즐겨찾기_생성_요청_응답) {
+        assertThat(즐겨찾기_생성_요청_응답.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    public static void 즐겨찾기_목록_조회됨(Long 즐겨찾기1, Long 즐겨찾기2, ExtractableResponse<Response> 즐겨찾기_목록_조회_응답) {
+        List<Long> 즐겨찾기_목록_조회_결과 = 즐겨찾기_목록_조회_응답.jsonPath().getList("id", Long.class);
+        assertAll(
+                () -> assertThat(즐겨찾기_목록_조회_응답.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(즐겨찾기_목록_조회_결과).containsExactly(즐겨찾기1, 즐겨찾기2)
+        );
+    }
+
+    public static void 내_즐겨찾기_목록만_조회됨(Long 내_즐겨찾기, Long 다른_사용자_즐겨찾기, ExtractableResponse<Response> 즐겨찾기_목록_조회_응답) {
+        List<Long> 즐겨찾기_목록_조회_결과 = 즐겨찾기_목록_조회_응답.jsonPath().getList("id", Long.class);
+        assertAll(
+                () -> assertThat(즐겨찾기_목록_조회_응답.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(즐겨찾기_목록_조회_결과).containsAnyOf(내_즐겨찾기),
+                () -> assertThat(즐겨찾기_목록_조회_결과).doesNotContain(다른_사용자_즐겨찾기)
+        );
+    }
+
+    public static void 다른_사용자의_즐겨찾기_삭제_실패(ExtractableResponse<Response> 즐겨찾기_삭제_응답) {
+        assertThat(즐겨찾기_삭제_응답.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+
+    public static void 즐겨찾기_삭제됨(Long 교대_양재_즐겨찾기, ExtractableResponse<Response> 즐겨찾기_목록_조회_요청_응답, ExtractableResponse<Response> 즐겨찾기_삭제_요청_응답) {
+        List<Long> 즐겨찾기_목록_조회_결과 = 즐겨찾기_목록_조회_요청_응답.jsonPath().getList("id", Long.class);
+        assertAll(
+                () -> assertThat(즐겨찾기_삭제_요청_응답.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                () -> assertThat(즐겨찾기_목록_조회_결과).doesNotContain(교대_양재_즐겨찾기).isEmpty()
+        );
+    }
+
+    public static void 권한없음(ExtractableResponse<Response> createResponse) {
+        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+}

--- a/src/test/java/nextstep/favorite/unit/FavoriteTest.java
+++ b/src/test/java/nextstep/favorite/unit/FavoriteTest.java
@@ -1,0 +1,28 @@
+package nextstep.favorite.unit;
+
+import nextstep.favorite.domain.Favorite;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class FavoriteTest {
+    @DisplayName("어떤 사용자에 의해 생성된 즐겨찾기인지 확인할 수 있다.")
+    @Test
+    void checkWhoseFavorite() {
+        // given
+        Long 사용자1 = 1L;
+        Long 사용자2 = 2L;
+        Station source = new Station("강남역");
+        Station target = new Station("역삼역");
+        Favorite favorite = new Favorite(사용자1, source, target);
+
+        // when & then
+        assertAll(
+                () -> assertThat(favorite.isCreatedBy(사용자1)).isTrue(),
+                () -> assertThat(favorite.isCreatedBy(사용자2)).isFalse()
+        );
+    }
+}

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -101,11 +101,9 @@ class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> getMyInfoResponse = 베이러_인증으로_내_회원_정보_조회_요청(accessToken);
 
         // then
-        Long id = getMyInfoResponse.jsonPath().getLong("id");
         String email = getMyInfoResponse.jsonPath().getString("email");
         Integer age = getMyInfoResponse.jsonPath().getInt("age");
         assertAll(
-                () -> assertThat(id).isEqualTo(1L),
                 () -> assertThat(email).isEqualTo("email@email.com"),
                 () -> assertThat(age).isEqualTo(20)
         );

--- a/src/test/java/nextstep/member/unit/MemberTest.java
+++ b/src/test/java/nextstep/member/unit/MemberTest.java
@@ -1,15 +1,14 @@
 package nextstep.member.unit;
 
-import nextstep.auth.exception.AuthenticationException;
-import nextstep.auth.exception.AuthorizationException;
-import nextstep.auth.exception.ErrorCode;
+import nextstep.common.exception.AuthenticationException;
+import nextstep.common.exception.ErrorCode;
 import nextstep.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class MemberTest {
+class MemberTest {
 
     @DisplayName("일치하지 않는 비밀번호 요청 시 예외가 발생한다.")
     @Test

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.*;
@@ -32,7 +31,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
         양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
 
-        Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
+        Map<String, String> lineCreateParams = createLineCreateParams("신분당선", "", 강남역, 양재역, 10);
         신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
     }
 
@@ -45,7 +44,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void addLineSection() {
         // when
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -62,7 +61,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void addLineSectionMiddle() {
         // when
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 정자역, 6));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -78,7 +77,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addSectionAlreadyIncluded() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역));
+        ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역, 6));
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -94,7 +93,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void removeLineSection() {
         // given
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // when
         지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
@@ -115,7 +114,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
     void removeLineSectionInMiddle() {
         // given
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // when
         지하철_노선에_지하철_구간_제거_요청(신분당선, 양재역);
@@ -124,24 +123,5 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 정자역);
-    }
-
-    private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", "신분당선");
-        lineCreateParams.put("color", "bg-red-600");
-        lineCreateParams.put("upStationId", upStationId + "");
-        lineCreateParams.put("downStationId", downStationId + "");
-        lineCreateParams.put("distance", 10 + "");
-        return lineCreateParams;
-    }
-
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
-        Map<String, String> params = new HashMap<>();
-        params.put("upStationId", upStationId + "");
-        params.put("downStationId", downStationId + "");
-        params.put("distance", 6 + "");
-        return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -21,6 +21,18 @@ public class LineSteps {
                 .then().log().all().extract();
     }
 
+    public static Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
+        Map<String, String> lineCreateParams;
+        lineCreateParams = new HashMap<>();
+        lineCreateParams.put("name", name);
+        lineCreateParams.put("color", color);
+        lineCreateParams.put("upStationId", upStation + "");
+        lineCreateParams.put("downStationId", downStation + "");
+        lineCreateParams.put("distance", distance + "");
+
+        return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+    }
+
     public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
         return RestAssured
                 .given().log().all()
@@ -63,5 +75,24 @@ public class LineSteps {
         return RestAssured.given().log().all()
                 .when().delete("/lines/{lineId}/sections?stationId={stationId}", lineId, stationId)
                 .then().log().all().extract();
+    }
+
+    public static Map<String, String> createLineCreateParams(String name, String color, Long upStationId, Long downStationId, int distance) {
+        Map<String, String> lineCreateParams;
+        lineCreateParams = new HashMap<>();
+        lineCreateParams.put("name", "신분당선");
+        lineCreateParams.put("color", "bg-red-600");
+        lineCreateParams.put("upStationId", upStationId + "");
+        lineCreateParams.put("downStationId", downStationId + "");
+        lineCreateParams.put("distance", distance + "");
+        return lineCreateParams;
+    }
+
+    public static Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", distance + "");
+        return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -1,18 +1,16 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.AcceptanceTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import static nextstep.subway.acceptance.LineSteps.createSectionCreateParams;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선_생성_요청;
 import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.PathSteps.두_역의_최단_거리_경로_조회를_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,33 +55,5 @@ class PathAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
-    }
-
-    private ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(Long source, Long target) {
-        return RestAssured
-                .given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/paths?source={sourceId}&target={targetId}", source, target)
-                .then().log().all().extract();
-    }
-
-    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", name);
-        lineCreateParams.put("color", color);
-        lineCreateParams.put("upStationId", upStation + "");
-        lineCreateParams.put("downStationId", downStation + "");
-        lineCreateParams.put("distance", distance + "");
-
-        return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
-    }
-
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
-        Map<String, String> params = new HashMap<>();
-        params.put("upStationId", upStationId + "");
-        params.put("downStationId", downStationId + "");
-        params.put("distance", distance + "");
-        return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/PathSteps.java
@@ -1,0 +1,16 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class PathSteps {
+    public static ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(Long source, Long target) {
+        return RestAssured
+                .given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/paths?source={sourceId}&target={targetId}", source, target)
+                .then().log().all().extract();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.*;
@@ -32,7 +31,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
         강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
         양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
 
-        Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
+        Map<String, String> lineCreateParams = createLineCreateParams("신분당선", "bg-red-600", 강남역, 양재역, 10);
         신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
     }
 
@@ -45,7 +44,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
     void addLineSection() {
         // when
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // then
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
@@ -63,7 +62,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
     void removeLineSection() {
         // given
         Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역, 6));
 
         // when
         지하철_노선에_지하철_구간_제거_요청(신분당선, 정자역);
@@ -72,24 +71,5 @@ class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역);
-    }
-
-    private Map<String, String> createLineCreateParams(Long upStationId, Long downStationId) {
-        Map<String, String> lineCreateParams;
-        lineCreateParams = new HashMap<>();
-        lineCreateParams.put("name", "신분당선");
-        lineCreateParams.put("color", "bg-red-600");
-        lineCreateParams.put("upStationId", upStationId + "");
-        lineCreateParams.put("downStationId", downStationId + "");
-        lineCreateParams.put("distance", 10 + "");
-        return lineCreateParams;
-    }
-
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
-        Map<String, String> params = new HashMap<>();
-        params.put("upStationId", upStationId + "");
-        params.put("downStationId", downStationId + "");
-        params.put("distance", 6 + "");
-        return params;
     }
 }

--- a/src/test/java/nextstep/utils/DataLoader.java
+++ b/src/test/java/nextstep/utils/DataLoader.java
@@ -1,0 +1,32 @@
+package nextstep.utils;
+
+import nextstep.auth.acceptance.fake.FakeGithubResponses;
+import nextstep.member.application.dto.MemberResponse;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import nextstep.member.domain.RoleType;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+
+@Profile("test")
+@Component
+public class DataLoader {
+    private final MemberRepository memberRepository;
+
+    public DataLoader(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void loadData() {
+        memberRepository.save(new Member("admin@email.com", "password", 29, Arrays.asList(RoleType.ROLE_ADMIN.name())));
+        memberRepository.save(new Member("member@email.com", "password", 29, Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(FakeGithubResponses.사용자1.getEmail(), "password", 29, Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(FakeGithubResponses.사용자2.getEmail(), "password", 29, Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(FakeGithubResponses.사용자3.getEmail(), "password", 29, Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(FakeGithubResponses.사용자4.getEmail(), "password", 29, Arrays.asList(RoleType.ROLE_MEMBER.name())));
+    }
+}

--- a/src/test/java/nextstep/utils/DataLoaderBootstrap.java
+++ b/src/test/java/nextstep/utils/DataLoaderBootstrap.java
@@ -1,9 +1,11 @@
-package nextstep;
+package nextstep.utils;
 
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
+@Profile("test")
 @Component
 public class DataLoaderBootstrap implements ApplicationListener<ContextRefreshedEvent> {
     private DataLoader dataLoader;


### PR DESCRIPTION
안녕하세요 이슬님! 3단계 미션 진행 후 PR 요청드립니다..!

지난 미션에서 피드백 주신 내용대로 Github docs 참고하여 실제 API 요청에 맞게 JsonProperty 추가하여 프론트는 없지만 간접적으로나마 API 를 쏴보며 실제 수동? 테스트를 해볼 수 있었습니다!

--- 

3단계 미션하기전에 즐겨 찾기 기능 요구사항 & 시나리오 작성 후 인수 테스트를 먼저 작성하고 기능을 구현하니 확실히 마음의 안정감이 오네요 ㅎㅎ
그런데, 즐겨찾기 생성에 대한 예외 테스트를 만들면서 2주차 미션 때 경로 찾기 기능에서 `역방향` 구간을 edge 로 등록하지 않았다는 사실을 깨달았습니다.. 
SubwayMap 클래스의 findPath 를 리팩터링 하면서 지난 2주차 미션때 리뷰어님께서 피드백 주신 내용과 함께 간단히 리팩터링 해보았습니다!

Favorite 도메인의 경우, 실제로 즐겨찾기 조회 후 직접적으로 역에 대한 정보들을 자주 사용하지만, 즐겨찾기가 속해있는 사용자에 대한 정보를 직접적으로 찾는 일은 적다고 판단하여 Station 은 직접 참조를, Member 는 간접참조로 만들어 보았습니다.

신나게 atdd cycle 경험하면서 기능을 만들다가 생성, 조회, 삭제에 나눠서 커밋했어야 했는데, 한번에 커밋을 해버린게 좀 아쉽습니다..

이번 미션 리뷰도 잘 부탁드립니다..!