### PR TITLE
🚀 Step3 - 즐겨찾기 기능 구현

### DIFF
--- a/src/main/java/nextstep/DataLoader.java
+++ b/src/main/java/nextstep/DataLoader.java
@@ -1,8 +1,8 @@
 package nextstep;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
+import nextstep.member.application.dto.MemberRequest;
 import nextstep.member.domain.MemberRepository;
 
 @Component
@@ -10,6 +10,7 @@ public class DataLoader {
 
     public void loadData() {
     }
+
     private final MemberRepository memberRepository;
 
     public DataLoader(MemberRepository memberRepository) {
@@ -19,5 +20,10 @@ public class DataLoader {
     public void loadGithubMemberData() {
         memberRepository.save(GithubAccountFixtures.ACCOUNT1.createMember());
         memberRepository.save(GithubAccountFixtures.ACCOUNT2.createMember());
+    }
+
+    public void loadMemberData(String email, String password, int age) {
+        MemberRequest memberRequest = new MemberRequest(email, password, age);
+        memberRepository.save(memberRequest.toMember());
     }
 }

--- a/src/main/java/nextstep/DataLoader.java
+++ b/src/main/java/nextstep/DataLoader.java
@@ -1,11 +1,13 @@
 package nextstep;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import nextstep.member.application.dto.MemberRequest;
 import nextstep.member.domain.MemberRepository;
 
 @Component
+@Profile("test")
 public class DataLoader {
 
     public void loadData() {

--- a/src/main/java/nextstep/argumentResolver/ErrorCode.java
+++ b/src/main/java/nextstep/argumentResolver/ErrorCode.java
@@ -2,7 +2,8 @@ package nextstep.argumentResolver;
 
 public enum ErrorCode {
     MISMATCH_BEARER_PREFIX_OF_JWT_TOKEN("Bearer Prefix가 정확하지 않습니다."),
-    UNVERIFIED_BEARER_TOKEN("해당 서비스에 사용되는 토큰이 아닙니다.");
+    UNVERIFIED_BEARER_TOKEN("해당 서비스에 사용되는 토큰이 아닙니다."),
+    UNREGISTERED_STATION("등록되지 않은 역입니다.");
 
     private final String message;
 

--- a/src/main/java/nextstep/argumentResolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/nextstep/argumentResolver/LoginMemberArgumentResolver.java
@@ -1,7 +1,7 @@
 package nextstep.argumentResolver;
 
-import java.util.Optional;
-
+import nextstep.exception.AuthorizationException;
+import nextstep.exception.InvalidValueException;
 import nextstep.member.application.JwtTokenProvider;
 import nextstep.member.application.dto.MemberResponse;
 import nextstep.member.application.service.MemberService;
@@ -47,7 +47,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         String accessToken = authorization.split(" ")[1];
 
         if (!jwtTokenProvider.validateToken(accessToken)) {
-            throw new IllegalArgumentException(accessToken);
+            throw new AuthorizationException("인증되지 않은 사용자입니다", accessToken);
         }
         String email = jwtTokenProvider.getPrincipal(accessToken);
         Member member = memberService.findMemberByEmail(email).orElseThrow(() -> new InvalidValueException(ErrorCode.UNVERIFIED_BEARER_TOKEN));

--- a/src/main/java/nextstep/exception/AuthorizationException.java
+++ b/src/main/java/nextstep/exception/AuthorizationException.java
@@ -1,0 +1,37 @@
+package nextstep.exception;
+
+public class AuthorizationException extends RuntimeException {
+
+    private String code;
+
+    private Object data;
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+
+    public AuthorizationException(String message, Object data) {
+        super(message);
+        this.data = data;
+    }
+
+    public AuthorizationException(String code, String message, Object data) {
+        super(message);
+        this.code = code;
+        this.data = data;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}
+

--- a/src/main/java/nextstep/exception/InvalidValueException.java
+++ b/src/main/java/nextstep/exception/InvalidValueException.java
@@ -1,4 +1,4 @@
-package nextstep.argumentResolver;
+package nextstep.exception;
 
 public class InvalidValueException extends RuntimeException {
     public InvalidValueException(Object p0) {

--- a/src/main/java/nextstep/subway/application/LineService.java
+++ b/src/main/java/nextstep/subway/application/LineService.java
@@ -1,9 +1,9 @@
-package nextstep.subway.applicaion;
+package nextstep.subway.application;
 
-import nextstep.subway.applicaion.dto.LineRequest;
-import nextstep.subway.applicaion.dto.LineResponse;
-import nextstep.subway.applicaion.dto.SectionRequest;
-import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.application.dto.LineRequest;
+import nextstep.subway.application.dto.LineResponse;
+import nextstep.subway.application.dto.SectionRequest;
+import nextstep.subway.application.dto.StationResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Station;

--- a/src/main/java/nextstep/subway/application/PathService.java
+++ b/src/main/java/nextstep/subway/application/PathService.java
@@ -1,6 +1,6 @@
-package nextstep.subway.applicaion;
+package nextstep.subway.application;
 
-import nextstep.subway.applicaion.dto.PathResponse;
+import nextstep.subway.application.dto.PathResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Station;

--- a/src/main/java/nextstep/subway/application/PathService.java
+++ b/src/main/java/nextstep/subway/application/PathService.java
@@ -29,14 +29,4 @@ public class PathService {
 
         return PathResponse.of(path);
     }
-
-    public boolean isConnected(Station source, Station target) {
-        List<Line> lines = lineService.findLines();
-        SubwayMap subwayMap = new SubwayMap(lines);
-
-        List<Station> stations = subwayMap.findPath(source, target)
-            .getSections()
-            .getStations();
-        return !stations.isEmpty();
-    }
 }

--- a/src/main/java/nextstep/subway/application/PathService.java
+++ b/src/main/java/nextstep/subway/application/PathService.java
@@ -5,6 +5,7 @@ import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.SubwayMap;
+
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,5 +28,15 @@ public class PathService {
         Path path = subwayMap.findPath(upStation, downStation);
 
         return PathResponse.of(path);
+    }
+
+    public boolean isConnected(Station source, Station target) {
+        List<Line> lines = lineService.findLines();
+        SubwayMap subwayMap = new SubwayMap(lines);
+
+        List<Station> stations = subwayMap.findPath(source, target)
+            .getSections()
+            .getStations();
+        return !stations.isEmpty();
     }
 }

--- a/src/main/java/nextstep/subway/application/StationService.java
+++ b/src/main/java/nextstep/subway/application/StationService.java
@@ -1,7 +1,7 @@
-package nextstep.subway.applicaion;
+package nextstep.subway.application;
 
-import nextstep.subway.applicaion.dto.StationRequest;
-import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.application.dto.StationRequest;
+import nextstep.subway.application.dto.StationResponse;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/nextstep/subway/application/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/application/dto/FavoriteRequest.java
@@ -1,0 +1,14 @@
+package nextstep.subway.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FavoriteRequest {
+    private final Long source;
+    private final Long target;
+
+    public FavoriteRequest(Long source, Long target) {
+        this.source = source;
+        this.target = target;
+    }
+}

--- a/src/main/java/nextstep/subway/application/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/application/dto/FavoriteResponse.java
@@ -19,7 +19,10 @@ public class FavoriteResponse {
         this.target = targetResponse;
     }
 
-    public static FavoriteResponse of(Favorite favorite, Station source, Station target) {
+    public static FavoriteResponse of(Favorite favorite) {
+
+        Station source = favorite.getSource();
+        Station target = favorite.getTarget();
 
         return FavoriteResponse.builder()
             .id(favorite.getId())

--- a/src/main/java/nextstep/subway/application/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/application/dto/FavoriteResponse.java
@@ -1,0 +1,30 @@
+package nextstep.subway.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import nextstep.subway.domain.Favorite;
+import nextstep.subway.domain.Station;
+
+@Getter
+public class FavoriteResponse {
+
+    private Long id;
+    private StationResponse source;
+    private StationResponse target;
+
+    @Builder
+    public FavoriteResponse(Long id, StationResponse sourceResponse, StationResponse targetResponse) {
+        this.id = id;
+        this.source = sourceResponse;
+        this.target = targetResponse;
+    }
+
+    public static FavoriteResponse of(Favorite favorite, Station source, Station target) {
+
+        return FavoriteResponse.builder()
+            .id(favorite.getId())
+            .sourceResponse(StationResponse.of(source))
+            .targetResponse(StationResponse.of(target))
+            .build();
+    }
+}

--- a/src/main/java/nextstep/subway/application/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/application/dto/LineRequest.java
@@ -1,17 +1,18 @@
-package nextstep.subway.applicaion.dto;
+package nextstep.subway.application.dto;
 
-public class SectionRequest {
+public class LineRequest {
+    private String name;
+    private String color;
     private Long upStationId;
     private Long downStationId;
     private int distance;
 
-    public SectionRequest() {
+    public String getName() {
+        return name;
     }
 
-    public SectionRequest(Long upStationId, Long downStationId, int distance) {
-        this.upStationId = upStationId;
-        this.downStationId = downStationId;
-        this.distance = distance;
+    public String getColor() {
+        return color;
     }
 
     public Long getUpStationId() {

--- a/src/main/java/nextstep/subway/application/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/application/dto/LineResponse.java
@@ -1,4 +1,4 @@
-package nextstep.subway.applicaion.dto;
+package nextstep.subway.application.dto;
 
 import nextstep.subway.domain.Line;
 

--- a/src/main/java/nextstep/subway/application/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/application/dto/PathResponse.java
@@ -1,4 +1,4 @@
-package nextstep.subway.applicaion.dto;
+package nextstep.subway.application.dto;
 
 import nextstep.subway.domain.Path;
 

--- a/src/main/java/nextstep/subway/application/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/application/dto/SectionRequest.java
@@ -1,18 +1,17 @@
-package nextstep.subway.applicaion.dto;
+package nextstep.subway.application.dto;
 
-public class LineRequest {
-    private String name;
-    private String color;
+public class SectionRequest {
     private Long upStationId;
     private Long downStationId;
     private int distance;
 
-    public String getName() {
-        return name;
+    public SectionRequest() {
     }
 
-    public String getColor() {
-        return color;
+    public SectionRequest(Long upStationId, Long downStationId, int distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
     }
 
     public Long getUpStationId() {

--- a/src/main/java/nextstep/subway/application/dto/StationRequest.java
+++ b/src/main/java/nextstep/subway/application/dto/StationRequest.java
@@ -1,4 +1,4 @@
-package nextstep.subway.applicaion.dto;
+package nextstep.subway.application.dto;
 
 public class StationRequest {
     private String name;

--- a/src/main/java/nextstep/subway/application/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/application/dto/StationResponse.java
@@ -1,4 +1,4 @@
-package nextstep.subway.applicaion.dto;
+package nextstep.subway.application.dto;
 
 import nextstep.subway.domain.Station;
 

--- a/src/main/java/nextstep/subway/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/domain/Favorite.java
@@ -1,0 +1,40 @@
+package nextstep.subway.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Favorite {
+
+    protected Favorite() {}
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne
+    private Station source;
+
+    @ManyToOne
+    private Station target;
+
+    public Favorite(Long memberId, Station source, Station target) {
+        this.memberId = memberId;
+        this.source = source;
+        this.target = target;
+    }
+
+    public static Favorite of(Long memberId, Station source, Station target) {
+        return new Favorite(memberId, source, target);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/domain/FavoriteRepository.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+}

--- a/src/main/java/nextstep/subway/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/domain/FavoriteRepository.java
@@ -1,7 +1,13 @@
 package nextstep.subway.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    Optional<Favorite> findByIdAndMemberId(Long id, Long memberId);
 
 }

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -6,6 +6,9 @@ public class Path {
     private Sections sections;
 
     public Path(Sections sections) {
+        if (sections.getStations().isEmpty()) {
+            throw new IllegalArgumentException("서로 연결되지 않은 역입니다.");
+        }
         this.sections = sections;
     }
 

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,9 +1,12 @@
 package nextstep.subway.ui;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import nextstep.exception.AuthorizationException;
 
 @ControllerAdvice
 public class ControllerExceptionHandler {
@@ -15,5 +18,10 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Void> handleIllegalArgsException(IllegalArgumentException e) {
         return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<Void> handleIllegalArgsException(AuthorizationException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -3,6 +3,7 @@ package nextstep.subway.ui;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,9 +31,16 @@ public class FavoriteController {
     }
 
     @GetMapping("/favorites/{favoriteId}")
-    public ResponseEntity<FavoriteResponse> createFavorites(@Login MemberResponse member,
+    public ResponseEntity<FavoriteResponse> getFavorites(@Login MemberResponse member,
         @PathVariable(value = "favoriteId") long favoriteId) {
         FavoriteResponse response = favoriteService.getFavorite(member.getId(), favoriteId);
         return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping("/favorites/{favoriteId}")
+    public ResponseEntity<FavoriteResponse> deleteFavorites(@Login MemberResponse member,
+        @PathVariable(value = "favoriteId") long favoriteId) {
+        favoriteService.deleteFavorite(member.getId(), favoriteId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -26,7 +26,6 @@ public class FavoriteController {
     public ResponseEntity<FavoriteResponse> createFavorites(@Login MemberResponse member,
         @RequestBody FavoriteRequest request) {
         FavoriteResponse response = favoriteService.createFavorite(member.getId(), request);
-        // return ResponseEntity.created(URI.create("/favorites/" + response.getId())).build();
         return ResponseEntity.created(URI.create("/favorites/" + response.getId())).body(response);
     }
 

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -1,0 +1,29 @@
+package nextstep.subway.ui;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import nextstep.argumentResolver.Login;
+import nextstep.member.application.dto.MemberResponse;
+import nextstep.subway.application.dto.FavoriteRequest;
+import nextstep.subway.application.dto.FavoriteResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @PostMapping("/favorites")
+    public ResponseEntity<FavoriteResponse> createFavorites(@Login MemberResponse member,
+        @RequestBody FavoriteRequest request) {
+        FavoriteResponse response = favoriteService.createFavorite(member.getId(), request);
+        return ResponseEntity.created(URI.create("/favorites/" + response.getId())).build();
+
+    }
+}

--- a/src/main/java/nextstep/subway/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteController.java
@@ -3,6 +3,8 @@ package nextstep.subway.ui;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +25,14 @@ public class FavoriteController {
     public ResponseEntity<FavoriteResponse> createFavorites(@Login MemberResponse member,
         @RequestBody FavoriteRequest request) {
         FavoriteResponse response = favoriteService.createFavorite(member.getId(), request);
-        return ResponseEntity.created(URI.create("/favorites/" + response.getId())).build();
+        // return ResponseEntity.created(URI.create("/favorites/" + response.getId())).build();
+        return ResponseEntity.created(URI.create("/favorites/" + response.getId())).body(response);
+    }
 
+    @GetMapping("/favorites/{favoriteId}")
+    public ResponseEntity<FavoriteResponse> createFavorites(@Login MemberResponse member,
+        @PathVariable(value = "favoriteId") long favoriteId) {
+        FavoriteResponse response = favoriteService.getFavorite(member.getId(), favoriteId);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/nextstep/subway/ui/FavoriteService.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteService.java
@@ -1,14 +1,11 @@
 package nextstep.subway.ui;
 
-import javax.lang.model.type.ErrorType;
-
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import nextstep.argumentResolver.ErrorCode;
 import nextstep.argumentResolver.InvalidValueException;
 import nextstep.subway.application.PathService;
-import nextstep.subway.application.dto.StationResponse;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
 import nextstep.subway.application.dto.FavoriteRequest;
@@ -24,6 +21,14 @@ public class FavoriteService {
     private final StationRepository stationRepository;
     private final PathService pathService;
 
+    public FavoriteResponse getFavorite(Long memberId, long favoriteId) {
+
+        Favorite favorite = favoriteRepository.findByIdAndMemberId(favoriteId, memberId)
+            .orElseThrow(() -> new InvalidValueException("등록되지 않은 값 입니다"));
+
+        return FavoriteResponse.of(favorite);
+    }
+
     public FavoriteResponse createFavorite(Long memberId, FavoriteRequest request) {
         Station sourceStation = getStation(request.getSource());
         Station targetStation = getStation(request.getTarget());
@@ -33,7 +38,7 @@ public class FavoriteService {
         }
 
         Favorite favorite = createFavorite(memberId, sourceStation, targetStation);
-        return FavoriteResponse.of(favorite, sourceStation, targetStation);
+        return FavoriteResponse.of(favorite);
     }
 
     private Favorite createFavorite(Long memberId, Station sourceStation, Station targetStation) {

--- a/src/main/java/nextstep/subway/ui/FavoriteService.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteService.java
@@ -1,6 +1,5 @@
 package nextstep.subway.ui;
 
-import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,17 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import nextstep.argumentResolver.ErrorCode;
 import nextstep.exception.InvalidValueException;
-import nextstep.subway.application.LineService;
 import nextstep.subway.application.PathService;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
 import nextstep.subway.application.dto.FavoriteRequest;
 import nextstep.subway.application.dto.FavoriteResponse;
-import nextstep.subway.domain.Line;
-import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
-import nextstep.subway.domain.SubwayMap;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/nextstep/subway/ui/FavoriteService.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteService.java
@@ -1,0 +1,49 @@
+package nextstep.subway.ui;
+
+import javax.lang.model.type.ErrorType;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import nextstep.argumentResolver.ErrorCode;
+import nextstep.argumentResolver.InvalidValueException;
+import nextstep.subway.application.PathService;
+import nextstep.subway.application.dto.StationResponse;
+import nextstep.subway.domain.Favorite;
+import nextstep.subway.domain.FavoriteRepository;
+import nextstep.subway.application.dto.FavoriteRequest;
+import nextstep.subway.application.dto.FavoriteResponse;
+import nextstep.subway.domain.Station;
+import nextstep.subway.domain.StationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final StationRepository stationRepository;
+    private final PathService pathService;
+
+    public FavoriteResponse createFavorite(Long memberId, FavoriteRequest request) {
+        Station sourceStation = getStation(request.getSource());
+        Station targetStation = getStation(request.getTarget());
+
+        if (!pathService.isConnected(sourceStation, targetStation)) {
+            throw new IllegalArgumentException("서로 연결되지 역입니다.");
+        }
+
+        Favorite favorite = createFavorite(memberId, sourceStation, targetStation);
+        return FavoriteResponse.of(favorite, sourceStation, targetStation);
+    }
+
+    private Favorite createFavorite(Long memberId, Station sourceStation, Station targetStation) {
+        Favorite favorite = Favorite.of(memberId, sourceStation, targetStation);
+        return favoriteRepository.save(favorite);
+    }
+
+    private Station getStation(Long id) {
+        return stationRepository.findById(id)
+            .orElseThrow(() -> new InvalidValueException(ErrorCode.UNREGISTERED_STATION));
+    }
+
+}

--- a/src/main/java/nextstep/subway/ui/FavoriteService.java
+++ b/src/main/java/nextstep/subway/ui/FavoriteService.java
@@ -1,18 +1,24 @@
 package nextstep.subway.ui;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import nextstep.argumentResolver.ErrorCode;
 import nextstep.exception.InvalidValueException;
+import nextstep.subway.application.LineService;
 import nextstep.subway.application.PathService;
 import nextstep.subway.domain.Favorite;
 import nextstep.subway.domain.FavoriteRepository;
 import nextstep.subway.application.dto.FavoriteRequest;
 import nextstep.subway.application.dto.FavoriteResponse;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
+import nextstep.subway.domain.SubwayMap;
 
 @Service
 @RequiredArgsConstructor
@@ -34,9 +40,7 @@ public class FavoriteService {
         Station sourceStation = getStation(request.getSource());
         Station targetStation = getStation(request.getTarget());
 
-        if (!pathService.isConnected(sourceStation, targetStation)) {
-            throw new IllegalArgumentException("서로 연결되지 역입니다.");
-        }
+        validateStations(sourceStation, targetStation);
 
         Favorite favorite = createFavorite(memberId, sourceStation, targetStation);
         return FavoriteResponse.of(favorite);
@@ -63,4 +67,7 @@ public class FavoriteService {
             .orElseThrow(() -> new InvalidValueException(ErrorCode.UNREGISTERED_STATION));
     }
 
+    private void validateStations(Station sourceStation, Station targetStation) {
+        pathService.findPath(sourceStation.getId(), targetStation.getId());
+    }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,9 +1,9 @@
 package nextstep.subway.ui;
 
-import nextstep.subway.applicaion.LineService;
-import nextstep.subway.applicaion.dto.LineRequest;
-import nextstep.subway.applicaion.dto.LineResponse;
-import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.application.LineService;
+import nextstep.subway.application.dto.LineRequest;
+import nextstep.subway.application.dto.LineResponse;
+import nextstep.subway.application.dto.SectionRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/nextstep/subway/ui/PathController.java
+++ b/src/main/java/nextstep/subway/ui/PathController.java
@@ -1,7 +1,7 @@
 package nextstep.subway.ui;
 
-import nextstep.subway.applicaion.PathService;
-import nextstep.subway.applicaion.dto.PathResponse;
+import nextstep.subway.application.PathService;
+import nextstep.subway.application.dto.PathResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/nextstep/subway/ui/StationController.java
+++ b/src/main/java/nextstep/subway/ui/StationController.java
@@ -1,8 +1,8 @@
 package nextstep.subway.ui;
 
-import nextstep.subway.applicaion.StationService;
-import nextstep.subway.applicaion.dto.StationRequest;
-import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.application.StationService;
+import nextstep.subway.application.dto.StationRequest;
+import nextstep.subway.application.dto.StationResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -15,13 +15,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
 
-import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.DataLoader;
 import nextstep.subway.utils.DatabaseCleanup;
 
+@ActiveProfiles("test")
 public class FavoriteAcceptanceTest extends AcceptanceTest {
 
     @Autowired
@@ -152,7 +153,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
 
         // given
         String 유저1의_토큰 = 토큰;
-        long 유저1의_즐겨찾기 = 즐겨찾기_생성_API(유저1의_토큰, 강남역, 교대역)
+        즐겨찾기_생성_API(유저1의_토큰, 강남역, 교대역)
             .jsonPath()
             .<Integer>get("id")
             .longValue();

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -1,17 +1,98 @@
 package nextstep.subway.acceptance;
 
+import static nextstep.subway.acceptance.FavoriteSteps.*;
+import static nextstep.subway.acceptance.LineSectionAcceptanceTest.*;
+import static nextstep.subway.acceptance.LineSteps.*;
+import static nextstep.subway.acceptance.MemberSteps.*;
+import static nextstep.subway.acceptance.StationSteps.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 
-public class FavoriteAcceptanceTest {
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.DataLoader;
+import nextstep.argumentResolver.InvalidValueException;
+import nextstep.subway.utils.DatabaseCleanup;
 
+public class FavoriteAcceptanceTest extends AcceptanceTest{
+
+    @Autowired
+    private DataLoader dataLoader;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    private Long 교대역;
+    private Long 강남역;
+    private Long 양재역;
+    private Long 역삼역;
+    private Long 남부터미널역;
+    private Long 이호선;
+    private Long 신분당선;
+    private Long 삼호선;
+    private static final String EMAIL = "admin@email.com";
+    private static final String PASSWORD = "password";
+    private static final int AGE = 20;
+
+
+    /**
+     * 교대역    --- *2호선* ---   강남역 --- *2호선* --- 역삼역
+     * |                           |
+     * *3호선*                   *신분당선*
+     * |                           |
+     * 남부터미널역  --- *3호선* ---   양재  --- *3호선* ---   매봉
+     */
+    @BeforeEach
+    public void setUp(){
+        databaseCleanup.execute();
+
+        교대역 = 지하철역_생성_요청("교대역").jsonPath().getLong("id");
+        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
+        남부터미널역 = 지하철역_생성_요청("남부터미널역").jsonPath().getLong("id");
+
+        이호선 = 지하철_노선_생성_요청("2호선", "green" ).jsonPath().getLong("id");
+        신분당선 = 지하철_노선_생성_요청("신분당선", "red").jsonPath().getLong("id");
+        삼호선 = 지하철_노선_생성_요청("3호선", "orange").jsonPath().getLong("id");
+
+        지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역));
+        지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(교대역, 남부터미널역));
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(교대역, 강남역));
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역));
+
+        dataLoader.loadMemberData(EMAIL, PASSWORD, AGE);
+    }
     @Test
     void 즐겨찾기_생성_테스트() {
+        // given
+        String 토큰 = ACCESS_TOKEN_발급(EMAIL, PASSWORD);
+
+        // when
+        ExtractableResponse<Response> response = 즐겨찾기_생성_API(토큰, 강남역, 교대역);
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.CREATED.value());
 
     }
 
     @Test
     void 즐겨찾기_생성_예외_테스트() {
 
+        // given
+        String 토큰 = ACCESS_TOKEN_발급(EMAIL, PASSWORD);
+
+        // when
+        ExtractableResponse<Response> response = 즐겨찾기_생성_API(토큰, 강남역, 역삼역);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     @Test
@@ -27,6 +108,18 @@ public class FavoriteAcceptanceTest {
     @Test
     void 비인증_유저_즐겨찾기_예외_테스트() {
 
+    }
+
+    private static String ACCESS_TOKEN_발급(String email, String password) {
+        return 베어러_인증_로그인_요청(email, password).jsonPath().getString("accessToken");
+    }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", 6 + "");
+        return params;
     }
 
 }

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -36,6 +36,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
 
     private static final String PASSWORD = "password";
     private static final String PASSWORD2 = "password2";
+    private String 유사토큰 = "%_this_token_means_nothing_%";
 
     private static final int AGE = 20;
 
@@ -179,7 +180,6 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
             .longValue();
 
         // when
-        String 유사토큰 = "2312kjsadfl124123123";
         int statusCode = 즐겨찾기_삭제_API(유사토큰, 유저1의_즐겨찾기).statusCode();
 
         // then

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,32 @@
+package nextstep.subway.acceptance;
+
+import org.junit.jupiter.api.Test;
+
+public class FavoriteAcceptanceTest {
+
+    @Test
+    void 즐겨찾기_생성_테스트() {
+
+    }
+
+    @Test
+    void 즐겨찾기_생성_예외_테스트() {
+
+    }
+
+    @Test
+    void 즐겨찾기_조회_테스트() {
+
+    }
+
+    @Test
+    void 즐겨찾기_삭제_테스트() {
+
+    }
+
+    @Test
+    void 비인증_유저_즐겨찾기_예외_테스트() {
+
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -30,7 +30,7 @@ public class FavoriteSteps {
             .extract();
     }
 
-    public static ExtractableResponse<Response> 즐겨찾기_조회_API(String token, String favoriteId) {
+    public static ExtractableResponse<Response> 즐겨찾기_조회_API(String token, Long favoriteId) {
         return RestAssured.given()
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .auth().oauth2(token)

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -1,0 +1,62 @@
+package nextstep.subway.acceptance;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class FavoriteSteps {
+
+    public static ExtractableResponse<Response> 즐겨찾기_생성_API(String token, Long source, Long target) {
+        Map<String, Long> params = new HashMap<>();
+        params.put("source", source);
+        params.put("target", target);
+
+        return RestAssured.given()
+            .header("Authorization", String.format("Bearer %s", token))
+            .log()
+            .all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .body(params)
+            .post("/favorites")
+            .then()
+            .log()
+            .all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_조회_API(String token, String favoriteId) {
+        return RestAssured.given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .auth().oauth2(token)
+            .log()
+            .all()
+            .when()
+            .get("/favorites/{favoriteId}", favoriteId)
+            .then()
+            .log()
+            .all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_삭제_API(String token, String favoriteId) {
+
+        return RestAssured.given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .auth().oauth2(token)
+            .log()
+            .all()
+            .when()
+            .delete("/favorites/{favoriteId}", favoriteId)
+            .then()
+            .log()
+            .all()
+            .extract();
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -17,7 +17,7 @@ public class FavoriteSteps {
         params.put("target", target);
 
         return RestAssured.given()
-            .header("Authorization", String.format("Bearer %s", token))
+            .auth().oauth2(token)
             .log()
             .all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteSteps.java
@@ -44,7 +44,7 @@ public class FavoriteSteps {
             .extract();
     }
 
-    public static ExtractableResponse<Response> 즐겨찾기_삭제_API(String token, String favoriteId) {
+    public static ExtractableResponse<Response> 즐겨찾기_삭제_API(String token, long favoriteId) {
 
         return RestAssured.given()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -3,7 +3,7 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.application.dto.StationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;

--- a/src/test/java/nextstep/subway/fake/GithubFakeClient.java
+++ b/src/test/java/nextstep/subway/fake/GithubFakeClient.java
@@ -1,6 +1,6 @@
 package nextstep.subway.fake;
 
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import nextstep.GithubAccountFixtures;
@@ -8,7 +8,7 @@ import nextstep.member.application.dto.GithubProfileResponse;
 import nextstep.member.application.service.GithubClient;
 
 @Component
-@Primary
+@Profile("test")
 public class GithubFakeClient extends GithubClient {
 
     @Override

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,8 +1,8 @@
 package nextstep.subway.unit;
 
-import nextstep.subway.applicaion.LineService;
-import nextstep.subway.applicaion.StationService;
-import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.application.LineService;
+import nextstep.subway.application.StationService;
+import nextstep.subway.application.dto.SectionRequest;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Station;

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,7 +1,7 @@
 package nextstep.subway.unit;
 
-import nextstep.subway.applicaion.LineService;
-import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.application.LineService;
+import nextstep.subway.application.dto.SectionRequest;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import nextstep.subway.domain.Station;


### PR DESCRIPTION
### PR
- 즐겨찾기 생성 / 조회 / 삭제 인수테스트 작성
- 인증되지 않은 유저, 데이터 삭제 시도 -> 예외 발생 -> 테스트 검증
- 인가되지 않은 데이터 삭제 시도 -> 예외 발생 -> 테스트 검증


### 고민
- FavoriteAcceptanceTest 클래스에 테스트케이스(조회/생성/삭제)를 모두 몰아 넣었습니다.
- 지금은 테스트케이스가 적어 큰 문제는 아니지만, 점점 케이스가 늘어난다면 조회/생성/삭제 케이스에 따라 AcceptanceTest 클래스를 분리하는 건 어떻게 생각하시나요? 중복되는 코드가 일정부분 생길 것 같은데, 테스트케이스를 카테고리화 하여 확인할 수 있어 가독성 측면에선 좋을 것 같습니다.