### PR TITLE
🚀 2단계 - 깃헙 로그인 인수 테스트

### DIFF
--- a/src/main/java/nextstep/auth/token/oauth2/github/GithubClient.java
+++ b/src/main/java/nextstep/auth/token/oauth2/github/GithubClient.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -32,14 +31,16 @@ public class GithubClient {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
 
-        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(
+        HttpEntity<GithubAccessTokenRequest> httpEntity = new HttpEntity<>(
             githubAccessTokenRequest, headers);
+
         RestTemplate restTemplate = new RestTemplate();
 
         String accessToken = restTemplate
             .exchange(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
             .getBody()
             .getAccessToken();
+
         if (accessToken == null) {
             throw new RuntimeException();
         }
@@ -50,7 +51,7 @@ public class GithubClient {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "token " + accessToken);
 
-        HttpEntity httpEntity = new HttpEntity<>(headers);
+        HttpEntity<HttpHeaders> httpEntity = new HttpEntity<>(headers);
         RestTemplate restTemplate = new RestTemplate();
 
         try {

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+security.jwt.token.secret-key= atdd-secret-key
+security.jwt.token.expire-length= 3600000
+
+github.client.id= client_id
+github.client.secret= client_secret
+github.url.access-token= http://localhost:8080/github/login/oauth/access_token
+github.url.profile= http://localhost:8080/github/user

--- a/src/test/java/nextstep/auth/acceptance/step/TokenSteps.java
+++ b/src/test/java/nextstep/auth/acceptance/step/TokenSteps.java
@@ -4,19 +4,33 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.auth.token.TokenRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.Map;
 
 public class TokenSteps {
     private TokenSteps() {
     }
 
-    public static ExtractableResponse<Response> 로그인_요청(String email, String password) {
+    public static ExtractableResponse<Response> 일반_로그인_요청(String email, String password) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new TokenRequest(email, password))
                 .when().post("/login/token")
                 .then().log().all()
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 깃허브_로그인_요청(String code) {
+        Map<String, String> params = Map.of("code", code);
+
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/login/github")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value()).extract();
     }
 
     public static String 토큰_추출(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static nextstep.auth.acceptance.step.TokenSteps.로그인_요청;
+import static nextstep.auth.acceptance.step.TokenSteps.일반_로그인_요청;
 import static nextstep.auth.acceptance.step.TokenSteps.토큰_추출;
 import static nextstep.member.acceptance.step.MemberSteps.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,7 +79,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
     void getMyInfo() {
         // given
         회원_생성_요청(EMAIL, PASSWORD, AGE);
-        String accessToken = 토큰_추출(로그인_요청(EMAIL, PASSWORD));
+        String accessToken = 토큰_추출(일반_로그인_요청(EMAIL, PASSWORD));
 
         // when
         ExtractableResponse<Response> getMyInfoResponse = 내_정보_조회_요청(accessToken);

--- a/src/test/java/nextstep/member/acceptance/step/MemberSteps.java
+++ b/src/test/java/nextstep/member/acceptance/step/MemberSteps.java
@@ -72,4 +72,8 @@ public class MemberSteps {
                 .then().log().all()
                 .extract();
     }
+
+    public static String 이메일_추출(ExtractableResponse<Response> response) {
+        return response.jsonPath().getString("email");
+    }
 }

--- a/src/test/java/nextstep/study/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/study/AuthAcceptanceTest.java
@@ -44,6 +44,11 @@ class AuthAcceptanceTest extends AcceptanceTest {
         assertThat(response.jsonPath().getString("accessToken")).isNotBlank();
     }
 
+    /**
+     * # 요구사항
+     * - GitHubClient의 요청이 Github이 아닌 GithubTestController에서 처리하게 하기
+     * - code에 해당하는 사용자 정보를 이용하여 AccessToken 응답받기
+     */
     @DisplayName("Github Auth")
     @Test
     void githubAuth() {

--- a/src/test/java/nextstep/study/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/study/AuthAcceptanceTest.java
@@ -1,8 +1,12 @@
 package nextstep.study;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import nextstep.utils.AcceptanceTest;
@@ -11,11 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "admin@email.com";
@@ -53,7 +52,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void githubAuth() {
         Map<String, String> params = new HashMap<>();
-        params.put("code", "code");
+        params.put("code", "code1");
 
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/study/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/study/AuthAcceptanceTest.java
@@ -40,6 +40,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void githubSetUp() {
+        githubTestRepository.cleanUp();
         githubTestRepository.addUser(userCode, new GithubTestUser(userEmail, 10));
     }
 

--- a/src/test/java/nextstep/study/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/study/AuthAcceptanceTest.java
@@ -1,20 +1,28 @@
 package nextstep.study;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.HashMap;
-import java.util.Map;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import nextstep.utils.AcceptanceTest;
+import nextstep.utils.GithubTestRepository;
+import nextstep.utils.GithubTestUser;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.auth.acceptance.step.TokenSteps.깃허브_로그인_요청;
+import static nextstep.auth.acceptance.step.TokenSteps.토큰_추출;
+import static nextstep.member.acceptance.step.MemberSteps.내_정보_조회_요청;
+import static nextstep.member.acceptance.step.MemberSteps.이메일_추출;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "admin@email.com";
@@ -23,6 +31,17 @@ class AuthAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private GithubTestRepository githubTestRepository;
+
+    private final String userCode = "code1";
+    private final String userEmail = "email1";
+
+    @BeforeEach
+    void githubSetUp() {
+        githubTestRepository.addUser(userCode, new GithubTestUser(userEmail, 10));
+    }
 
     @DisplayName("Bearer Auth")
     @Test
@@ -44,23 +63,38 @@ class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     /**
-     * # 요구사항
-     * - GitHubClient의 요청이 Github이 아닌 GithubTestController에서 처리하게 하기
-     * - code에 해당하는 사용자 정보를 이용하여 AccessToken 응답받기
+     * When : Github 로그인을 요청하면
+     * Then : AccessToken이 발급된다
      */
     @DisplayName("Github Auth")
     @Test
     void githubAuth() {
-        Map<String, String> params = new HashMap<>();
-        params.put("code", "code1");
+        // when
+        ExtractableResponse<Response> githubLoginResponse = 깃허브_로그인_요청(userCode);
 
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
-                .when().post("/login/github")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value()).extract();
+        // then
+        assertThat(토큰_추출(githubLoginResponse)).isNotBlank();
+    }
 
-        assertThat(response.jsonPath().getString("accessToken")).isNotBlank();
+    /**
+     * Given : Github 로그인을 요청하고
+     * And : AccessToken을 발급받은 후
+     * When : 내 정보 조회를 요청하면
+     * Then : 조회가 성공한다.
+     */
+    @DisplayName("Github 인증 후 토큰으로 내정보 요청")
+    @Test
+    void githubAuth2() {
+        // given
+        String accessToken = 토큰_추출(깃허브_로그인_요청(userCode));
+
+        // when
+        ExtractableResponse<Response> response = 내_정보_조회_요청(accessToken);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        String email = 이메일_추출(response);
+        assertThat(email).isEqualTo(userEmail);
     }
 }

--- a/src/test/java/nextstep/utils/GithubTestController.java
+++ b/src/test/java/nextstep/utils/GithubTestController.java
@@ -4,14 +4,20 @@ import nextstep.auth.token.oauth2.github.GithubAccessTokenRequest;
 import nextstep.auth.token.oauth2.github.GithubAccessTokenResponse;
 import nextstep.auth.token.oauth2.github.GithubProfileResponse;
 import org.junit.platform.commons.util.StringUtils;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class GithubTestController {
+    private final GithubTestRepository githubTestRepository;
+
+    public GithubTestController(GithubTestRepository githubTestRepository) {
+        this.githubTestRepository = githubTestRepository;
+    }
 
     @PostMapping("/github/login/oauth/access_token")
     public ResponseEntity<GithubAccessTokenResponse> accessToken(@RequestBody GithubAccessTokenRequest githubAccessTokenRequest) {
@@ -23,15 +29,12 @@ public class GithubTestController {
             return ResponseEntity.badRequest().build();
         }
 
-        GithubAccessTokenResponse response = new GithubAccessTokenResponse("githubAccessToken: " + code, "testType", "testScope", "test");
+        GithubAccessTokenResponse response = new GithubAccessTokenResponse("githubAccessToken: " + code, "bearer", "testScope", "test");
         return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/github/user")
-    public ResponseEntity<GithubProfileResponse> user(@RequestHeader HttpHeaders headers) {
-        List<String> authorization = headers.get("Authorization");
-        String githubAccessToken = authorization.get(0);
-
+    public ResponseEntity<GithubProfileResponse> user(@RequestHeader("Authorization") String githubAccessToken) {
         if (StringUtils.isBlank(githubAccessToken)) {
             return ResponseEntity.badRequest().build();
         }

--- a/src/test/java/nextstep/utils/GithubTestController.java
+++ b/src/test/java/nextstep/utils/GithubTestController.java
@@ -1,23 +1,43 @@
 package nextstep.utils;
 
+import nextstep.auth.token.oauth2.github.GithubAccessTokenRequest;
 import nextstep.auth.token.oauth2.github.GithubAccessTokenResponse;
 import nextstep.auth.token.oauth2.github.GithubProfileResponse;
+import org.junit.platform.commons.util.StringUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 public class GithubTestController {
 
     @PostMapping("/github/login/oauth/access_token")
-    public ResponseEntity<GithubAccessTokenResponse> accessToken() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<GithubAccessTokenResponse> accessToken(@RequestBody GithubAccessTokenRequest githubAccessTokenRequest) {
+        String clientId = githubAccessTokenRequest.getClient_id();
+        String clientSecret = githubAccessTokenRequest.getClient_secret();
+        String code = githubAccessTokenRequest.getCode();
+
+        if (StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret) || StringUtils.isBlank(code)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        GithubAccessTokenResponse response = new GithubAccessTokenResponse("githubAccessToken: " + code, "testType", "testScope", "test");
+        return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/github/user")
-    public ResponseEntity<GithubProfileResponse> user() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<GithubProfileResponse> user(@RequestHeader HttpHeaders headers) {
+        List<String> authorization = headers.get("Authorization");
+        String githubAccessToken = authorization.get(0);
+
+        if (StringUtils.isBlank(githubAccessToken)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        GithubProfileResponse response = new GithubProfileResponse("email", 12);
+        return ResponseEntity.ok().body(response);
     }
 }
 

--- a/src/test/java/nextstep/utils/GithubTestController.java
+++ b/src/test/java/nextstep/utils/GithubTestController.java
@@ -29,6 +29,10 @@ public class GithubTestController {
             return ResponseEntity.badRequest().build();
         }
 
+        if (!githubTestRepository.isUserExist(code)) {
+            return ResponseEntity.badRequest().build();
+        }
+
         GithubAccessTokenResponse response = new GithubAccessTokenResponse("githubAccessToken: " + code, "bearer", "testScope", "test");
         return ResponseEntity.ok().body(response);
     }
@@ -39,7 +43,13 @@ public class GithubTestController {
             return ResponseEntity.badRequest().build();
         }
 
-        GithubProfileResponse response = new GithubProfileResponse("email", 12);
+        String code = githubAccessToken.split(": ")[1];
+        if (!githubTestRepository.isUserExist(code)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        GithubTestUser user = githubTestRepository.findByCode(code);
+        GithubProfileResponse response = new GithubProfileResponse(user.getEmail(), user.getAge());
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/test/java/nextstep/utils/GithubTestController.java
+++ b/src/test/java/nextstep/utils/GithubTestController.java
@@ -25,7 +25,7 @@ public class GithubTestController {
         String clientSecret = githubAccessTokenRequest.getClient_secret();
         String code = githubAccessTokenRequest.getCode();
 
-        if (StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret) || StringUtils.isBlank(code)) {
+        if (validateNotBlank(clientId, clientSecret, code)) {
             return ResponseEntity.badRequest().build();
         }
 
@@ -35,6 +35,10 @@ public class GithubTestController {
 
         GithubAccessTokenResponse response = new GithubAccessTokenResponse("githubAccessToken: " + code, "bearer", "testScope", "test");
         return ResponseEntity.ok().body(response);
+    }
+
+    private boolean validateNotBlank(String clientId, String clientSecret, String code) {
+        return StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret) || StringUtils.isBlank(code);
     }
 
     @GetMapping("/github/user")

--- a/src/test/java/nextstep/utils/GithubTestRepository.java
+++ b/src/test/java/nextstep/utils/GithubTestRepository.java
@@ -1,0 +1,16 @@
+package nextstep.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GithubTestRepository {
+    private final Map<String, GithubTestUser> USER_REPOSITORY = new HashMap<>();
+
+    public GithubTestRepository() {
+        IntStream.rangeClosed(1, 3)
+                .forEach(num -> USER_REPOSITORY.put("code" + num, new GithubTestUser("email" + num, num)));
+    }
+}

--- a/src/test/java/nextstep/utils/GithubTestRepository.java
+++ b/src/test/java/nextstep/utils/GithubTestRepository.java
@@ -13,4 +13,12 @@ public class GithubTestRepository {
         IntStream.rangeClosed(1, 3)
                 .forEach(num -> USER_REPOSITORY.put("code" + num, new GithubTestUser("email" + num, num)));
     }
+
+    public boolean isUserExist(String code) {
+        return USER_REPOSITORY.containsKey(code);
+    }
+
+    public GithubTestUser findByCode(String code) {
+        return USER_REPOSITORY.get(code);
+    }
 }

--- a/src/test/java/nextstep/utils/GithubTestRepository.java
+++ b/src/test/java/nextstep/utils/GithubTestRepository.java
@@ -24,4 +24,8 @@ public class GithubTestRepository {
     public GithubTestUser findByCode(String code) {
         return USER_REPOSITORY.get(code);
     }
+
+    public void cleanUp() {
+        USER_REPOSITORY.clear();
+    }
 }

--- a/src/test/java/nextstep/utils/GithubTestRepository.java
+++ b/src/test/java/nextstep/utils/GithubTestRepository.java
@@ -1,17 +1,20 @@
 package nextstep.utils;
 
+import org.springframework.stereotype.Repository;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.IntStream;
-import org.springframework.stereotype.Repository;
 
 @Repository
 public class GithubTestRepository {
     private final Map<String, GithubTestUser> USER_REPOSITORY = new HashMap<>();
 
-    public GithubTestRepository() {
-        IntStream.rangeClosed(1, 3)
-                .forEach(num -> USER_REPOSITORY.put("code" + num, new GithubTestUser("email" + num, num)));
+    public void addUser(String code, GithubTestUser user) {
+        if (isUserExist(code)) {
+            throw new IllegalArgumentException("이미 존재하는 code");
+        }
+
+        USER_REPOSITORY.put(code, user);
     }
 
     public boolean isUserExist(String code) {

--- a/src/test/java/nextstep/utils/GithubTestUser.java
+++ b/src/test/java/nextstep/utils/GithubTestUser.java
@@ -1,0 +1,19 @@
+package nextstep.utils;
+
+public class GithubTestUser {
+    private final String email;
+    private final int age;
+
+    public GithubTestUser(String email, int age) {
+        this.email = email;
+        this.age = age;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}


### PR DESCRIPTION
이번 미션이 쉬운듯 하면서도 고민되는 부분이 많아서, 절대적인 코드량은 적지만 시간이 좀 걸렸네요 😅

이번 미션에서의 주요 고민 포인트는 다음과 같았습니당.

### GithubTestRepository
- code에 해당하는 사용자가 로그인하는 것처럼 구성하기 위해 아주 간단한 저장소인 GithubTestRepository를 만들었는데요. 너무 간단해서 테스트 하는 목적을 달성할 수 있을지가 의문입니다. 즉, 해당 저장소가 최대한 실제 GithubController에 테스트를 보내는 것 처럼 작동해야 할것 같은데, 어느 정도까지 비슷하게 만들어야 할지가 고민이었어요. (고민만 하다가는 끝이 안날것 같아서 일단 제가 구현한 상태 그대로 PR을 보냅니다ㅎㅎ;)


### Github에서 발급해주는 AccessToken의 형태 
- github에서 발급해주는 토큰의 형태를 테스트하기 편하게 임의로 `githubAccessToken: {코드값}`형태로 발급을 해주고 있습니다. 해당 토큰으로 사용자 정보를 요청할 때는 `split(": ")`을 이용해서 파싱해서 사용하고 있어요. 이런 방식으로 제 생각대로 구현을 해도, 테스트가 유의미하다고 볼 수 있는걸까요? 


### 전반적인... (사실 위 두 고민도 아래의 고민으로 통합될 수 있을 것 같네요 ㅎㅎ;)
전반적으로 제가 구성한 `GithubTestController`가 테스트에서 제 역할을 하는지가 의문이에요. 이러한 구성은 처음 해보았기 때문에, 어느 정도까지 구현을 해야할지, 혹은 제가 너무 부족하게 구현한건 아닐지, 너무 과하게 구현한건 아닐지에 대한 고민이 있습니다.


