### PR TITLE
🚀 1단계: 내 정보 조회 기능 구현

### DIFF
--- a/src/main/java/nextstep/auth/oauth2/vo/CustomOAuth2User.java
+++ b/src/main/java/nextstep/auth/oauth2/vo/CustomOAuth2User.java
@@ -1,0 +1,32 @@
+package nextstep.auth.oauth2.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import nextstep.auth.oauth2.dto.OAuth2User;
+import nextstep.member.entity.Member;
+
+@Builder
+public class CustomOAuth2User implements OAuth2User {
+
+    @Getter
+    private String email;
+
+    private String role;
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getRole() {
+        return role;
+    }
+
+    public static CustomOAuth2User of(Member member) {
+        return CustomOAuth2User.builder()
+                .email(member.getEmail())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/src/main/java/nextstep/auth/principal/UserPrincipal.java
+++ b/src/main/java/nextstep/auth/principal/UserPrincipal.java
@@ -4,11 +4,15 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Builder
-@Getter
 public class UserPrincipal {
 
     private String username;
 
+    @Getter
     private String role;
+
+    public String getEmail() {
+        return username;
+    }
 
 }

--- a/src/main/java/nextstep/auth/token/service/JwtTokenProvider.java
+++ b/src/main/java/nextstep/auth/token/service/JwtTokenProvider.java
@@ -9,11 +9,15 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
-    @Value("${security.jwt.token.secret-key}")
-    private String secretKey;
+    private final String secretKey;
 
-    @Value("${security.jwt.token.expire-length}")
-    private long validityInMilliseconds;
+    private final long validityInMilliseconds;
+
+    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") String secretKey,
+                            @Value("${security.jwt.token.expire-length}") long validityInMilliseconds) {
+        this.secretKey = secretKey;
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
 
     public String createToken(String principal, String role) {
         Claims claims = Jwts.claims().setSubject(principal);

--- a/src/main/java/nextstep/auth/userdetails/CustomUserDetails.java
+++ b/src/main/java/nextstep/auth/userdetails/CustomUserDetails.java
@@ -1,0 +1,47 @@
+package nextstep.auth.userdetails;
+
+import lombok.Builder;
+import lombok.Getter;
+import nextstep.member.entity.Member;
+
+import java.util.Objects;
+
+@Builder
+public class CustomUserDetails implements UserDetails {
+
+    @Getter
+    private String email;
+
+    private String password;
+
+    private String role;
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getRole() {
+        return role;
+    }
+
+    @Override
+    public boolean checkPassword(String password) {
+        return Objects.equals(this.password, password);
+    }
+
+    public static CustomUserDetails of(Member member) {
+        return CustomUserDetails.builder()
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .role(member.getRole())
+                .build();
+    }
+
+}

--- a/src/main/java/nextstep/member/controller/MemberController.java
+++ b/src/main/java/nextstep/member/controller/MemberController.java
@@ -1,6 +1,8 @@
 package nextstep.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import nextstep.auth.principal.AuthenticationPrincipal;
+import nextstep.auth.principal.UserPrincipal;
 import nextstep.member.service.MemberService;
 import nextstep.member.dto.MemberRequest;
 import nextstep.member.dto.MemberResponse;
@@ -18,30 +20,41 @@ public class MemberController {
     @PostMapping("/members")
     public ResponseEntity<Void> createMember(@RequestBody MemberRequest request) {
         MemberResponse member = memberService.createMember(request);
-        return ResponseEntity.created(URI.create("/members/" + member.getId())).build();
+        URI uri = URI.create(String.format("/members/%d", member.getId()));
+
+        return ResponseEntity
+                .created(uri)
+                .build();
     }
 
     @GetMapping("/members/{id}")
     public ResponseEntity<MemberResponse> findMember(@PathVariable Long id) {
         MemberResponse member = memberService.findMember(id);
-        return ResponseEntity.ok().body(member);
+
+        return ResponseEntity.ok(member);
     }
 
     @PutMapping("/members/{id}")
     public ResponseEntity<MemberResponse> updateMember(@PathVariable Long id, @RequestBody MemberRequest param) {
         memberService.updateMember(id, param);
-        return ResponseEntity.ok().build();
+
+        return ResponseEntity.ok()
+                .build();
     }
 
     @DeleteMapping("/members/{id}")
     public ResponseEntity<MemberResponse> deleteMember(@PathVariable Long id) {
         memberService.deleteMember(id);
-        return ResponseEntity.noContent().build();
+
+        return ResponseEntity.noContent()
+                .build();
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        MemberResponse member = memberService.findMemberByEmail(userPrincipal.getEmail());
+
+        return ResponseEntity.ok(member);
     }
 }
 

--- a/src/main/java/nextstep/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/nextstep/member/service/CustomOAuth2UserService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import nextstep.auth.oauth2.dto.OAuth2User;
 import nextstep.auth.oauth2.dto.OAuth2UserRequest;
 import nextstep.auth.oauth2.service.OAuth2UserService;
-import nextstep.member.entity.CustomOAuth2User;
+import nextstep.auth.oauth2.vo.CustomOAuth2User;
 import nextstep.member.entity.Member;
 import nextstep.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/nextstep/member/service/CustomUserDetailsService.java
+++ b/src/main/java/nextstep/member/service/CustomUserDetailsService.java
@@ -1,10 +1,10 @@
 package nextstep.member.service;
 
 import lombok.RequiredArgsConstructor;
+import nextstep.auth.userdetails.CustomUserDetails;
 import nextstep.auth.userdetails.UserDetails;
 import nextstep.auth.userdetails.UserDetailsService;
 import nextstep.member.adapters.persistence.MemberAdapter;
-import nextstep.member.entity.CustomUserDetails;
 import nextstep.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/nextstep/constants/Endpoint.java
+++ b/src/test/java/nextstep/constants/Endpoint.java
@@ -5,7 +5,8 @@ public enum Endpoint {
     STATION_BASE_URL("/stations"),
     LINE_BASE_URL("/lines"),
     PATH_BASE_URL("/paths"),
-    MEMBER_BASE_URL("/members");
+    MEMBER_BASE_URL("/members"),
+    LOGIN_BASE_URL("/login");
 
     private final String url;
 

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -2,6 +2,7 @@ package nextstep.member.acceptance;
 
 import io.restassured.RestAssured;
 import nextstep.member.dto.MemberRequest;
+import nextstep.member.dto.MemberResponse;
 import nextstep.support.AcceptanceTest;
 import nextstep.support.AssertUtils;
 import nextstep.support.DatabaseCleanup;
@@ -13,6 +14,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 
 import static io.restassured.RestAssured.UNDEFINED_PORT;
+import static nextstep.member.acceptance.step.AuthStep.일반_로그인_요청;
 import static nextstep.member.acceptance.step.MemberStep.*;
 import static nextstep.member.fixture.MemberFixture.회원_정보_DTO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,13 +95,24 @@ class MemberAcceptanceTest {
 
     /**
      * Given 회원 가입을 생성하고
-     * And 로그인을 하고
+     * Given 로그인을 하고
      * When 토큰을 통해 내 정보를 조회하면
      * Then 내 정보를 조회할 수 있다
      */
     @DisplayName("내 정보를 조회한다.")
     @Test
     void getMyInfo() {
+        // given
+        회원_생성_요청(회원_정보_DTO);
 
+        var 로그인_응답 = 일반_로그인_요청(회원_정보_DTO.getEmail(), 회원_정보_DTO.getPassword());
+
+        // when
+        var 내_정보_조회_응답 = 내_정보_조회_요청(로그인_응답);
+
+        // then
+        String 이메일 = 회원_정보_DTO.getEmail();
+        Integer 나이 = 회원_정보_DTO.getAge();
+        회원_정보_조회됨(내_정보_조회_응답, 이메일, 나이);
     }
 }

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -2,7 +2,6 @@ package nextstep.member.acceptance;
 
 import io.restassured.RestAssured;
 import nextstep.member.dto.MemberRequest;
-import nextstep.member.dto.MemberResponse;
 import nextstep.support.AcceptanceTest;
 import nextstep.support.AssertUtils;
 import nextstep.support.DatabaseCleanup;

--- a/src/test/java/nextstep/member/acceptance/step/AuthStep.java
+++ b/src/test/java/nextstep/member/acceptance/step/AuthStep.java
@@ -1,0 +1,32 @@
+package nextstep.member.acceptance.step;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.auth.token.dto.TokenRequest;
+import nextstep.constants.Endpoint;
+import nextstep.support.RestAssuredClient;
+
+public class AuthStep {
+
+    private static final String LOGIN_BASE_URL = Endpoint.LOGIN_BASE_URL.getUrl();
+
+    /**
+     * <pre>
+     * 일반 로그인 API를 호출하는 함수
+     * </pre>
+     *
+     * @param email 이메일
+     * @param password 비밀번호
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 일반_로그인_요청(String email, String password) {
+        TokenRequest 일반_로그인_요청_DTO = TokenRequest.builder()
+                .email(email)
+                .password(password)
+                .build();
+        String uri = String.format("/%s/token", LOGIN_BASE_URL);
+
+        return RestAssuredClient.post(uri, 일반_로그인_요청_DTO);
+    }
+
+}

--- a/src/test/java/nextstep/member/acceptance/step/AuthStep.java
+++ b/src/test/java/nextstep/member/acceptance/step/AuthStep.java
@@ -24,7 +24,7 @@ public class AuthStep {
                 .email(email)
                 .password(password)
                 .build();
-        String uri = String.format("/%s/token", LOGIN_BASE_URL);
+        String uri = String.format("%s/token", LOGIN_BASE_URL);
 
         return RestAssuredClient.post(uri, 일반_로그인_요청_DTO);
     }

--- a/src/test/java/nextstep/member/acceptance/step/MemberStep.java
+++ b/src/test/java/nextstep/member/acceptance/step/MemberStep.java
@@ -81,7 +81,7 @@ public class MemberStep {
     public static ExtractableResponse<Response> 내_정보_조회_요청(ExtractableResponse<Response> response) {
         TokenResponse tokenResponse = response.as(TokenResponse.class);
         String accessToken = tokenResponse.getAccessToken();
-        String uri = String.format("/%s/me", MEMBER_BASE_URL);
+        String uri = String.format("%s/me", MEMBER_BASE_URL);
 
         return RestAssuredClient.get(uri, accessToken);
     }

--- a/src/test/java/nextstep/member/acceptance/step/MemberStep.java
+++ b/src/test/java/nextstep/member/acceptance/step/MemberStep.java
@@ -2,6 +2,7 @@ package nextstep.member.acceptance.step;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.auth.token.dto.TokenResponse;
 import nextstep.constants.Endpoint;
 import nextstep.member.dto.MemberRequest;
 import nextstep.member.dto.MemberResponse;
@@ -14,28 +15,87 @@ public class MemberStep {
 
     private static final String MEMBER_BASE_URL = Endpoint.MEMBER_BASE_URL.getUrl();
 
+    /**
+     * <pre>
+     * 회원을 생성하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param memberRequest 회원 생성 요청 DTO
+     * @return ExtractableResponse
+     */
     public static ExtractableResponse<Response> 회원_생성_요청(MemberRequest memberRequest) {
         return RestAssuredClient.post(MEMBER_BASE_URL, memberRequest);
     }
 
+    /**
+     * <pre>
+     * 회원 정보를 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param response RestAssured를 통해 API 응답 받은 응답 객체
+     * @return ExtractableResponse
+     */
     public static ExtractableResponse<Response> 회원_정보_조회_요청(ExtractableResponse<Response> response) {
         String uri = response.header("Location");
 
         return RestAssuredClient.get(uri);
     }
 
+    /**
+     * <pre>
+     * 회원 정보를 수정하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param response RestAssured를 통해 API 응답 받은 응답 객체
+     * @param memberRequest 회원 수정 요청 DTO
+     * @return ExtractableResponse
+     */
     public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, MemberRequest memberRequest) {
         String uri = response.header("Location");
 
         return RestAssuredClient.put(uri, memberRequest);
     }
 
+    /**
+     * <pre>
+     * 회원을 삭제하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param response RestAssured를 통해 API 응답 받은 응답 객체
+     * @return ExtractableResponse
+     */
     public static ExtractableResponse<Response> 회원_삭제_요청(ExtractableResponse<Response> response) {
         String uri = response.header("Location");
 
         return RestAssuredClient.delete(uri);
     }
 
+    /**
+     * <pre>
+     * 현재 로그인한 회원의 정보를 조회하는 API를 호출하는 함수
+     * </pre>
+     *
+     * @param response RestAssured를 통해 로그인 API를 호출해서 응답 받은 응답 객체
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> 내_정보_조회_요청(ExtractableResponse<Response> response) {
+        TokenResponse tokenResponse = response.as(TokenResponse.class);
+        String accessToken = tokenResponse.getAccessToken();
+        String uri = String.format("/%s/me", MEMBER_BASE_URL);
+
+        return RestAssuredClient.get(uri, accessToken);
+    }
+
+    /**
+     * <pre>
+     * 회원 정보가 잘 조회되었는지 검증하는 함수
+     * </pre>
+     *
+     * @param response RestAssured를 통해 회원 정보 조회 API 응답 받은 응답 객체
+     * @param email 검증 기준이 될 이메일
+     * @param age 검증 기준이 될 나이
+     * @return ExtractableResponse
+     */
     public static void 회원_정보_조회됨(ExtractableResponse<Response> response, String email, int age) {
         MemberResponse 회원_정보_조회_응답 = response.as(MemberResponse.class);
 

--- a/src/test/java/nextstep/member/fixture/MemberFixture.java
+++ b/src/test/java/nextstep/member/fixture/MemberFixture.java
@@ -11,7 +11,7 @@ public class MemberFixture {
             .age(27)
             .build();
 
-    public static Member 회원_정보_엔티티 = Member.builder()
+    public static Member 회원_정보 = Member.builder()
             .email("test@gmail.com")
             .password("testpassword123")
             .age(27)

--- a/src/test/java/nextstep/member/unit/token/JwtTokenProviderTest.java
+++ b/src/test/java/nextstep/member/unit/token/JwtTokenProviderTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static nextstep.member.fixture.MemberFixture.회원_정보;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest(classes = {JwtTokenProvider.class})
 public class JwtTokenProviderTest {
 
     @Autowired
@@ -41,5 +41,23 @@ public class JwtTokenProviderTest {
         // then
         assertThat(isValid).isFalse();
     }
+
+    @Test
+    @DisplayName("기간이 만료된 토큰을 전달 받았을 때 검증에 실패한다.")
+    void failValidateExpiredToken() {
+        // given
+        String secretKey = "atdd-secret-key";
+        long validityInMilliseconds = 1L;
+        tokenProvider = new JwtTokenProvider(secretKey, validityInMilliseconds);
+
+        String token = tokenProvider.createToken(회원_정보.getEmail(), RoleType.ROLE_MEMBER.name());
+
+        // when
+        boolean isValid = tokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
 
 }

--- a/src/test/java/nextstep/member/unit/token/JwtTokenProviderTest.java
+++ b/src/test/java/nextstep/member/unit/token/JwtTokenProviderTest.java
@@ -1,0 +1,45 @@
+package nextstep.member.unit.token;
+
+import nextstep.auth.token.service.JwtTokenProvider;
+import nextstep.member.constants.RoleType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static nextstep.member.fixture.MemberFixture.회원_정보;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class JwtTokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("올바른 토큰을 전달 받았을 때 검증에 성공한다.")
+    void successValidateToken() {
+        // given
+        String token = tokenProvider.createToken(회원_정보.getEmail(), RoleType.ROLE_MEMBER.name());
+
+        // when
+        boolean isValid = tokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 토큰을 전달 받았을 때 검증에 실패한다.")
+    void failValidateToken() {
+        // given
+        String token = "not_valid_token";
+
+        // when
+        boolean isValid = tokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+}

--- a/src/test/java/nextstep/study/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/study/AuthAcceptanceTest.java
@@ -16,7 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 import static io.restassured.RestAssured.UNDEFINED_PORT;
-import static nextstep.member.fixture.MemberFixture.회원_정보_엔티티;
+import static nextstep.member.acceptance.step.MemberStep.회원_생성_요청;
+import static nextstep.member.fixture.MemberFixture.회원_정보_DTO;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @AcceptanceTest
@@ -38,15 +39,15 @@ class AuthAcceptanceTest {
         }
         databaseCleanUp.execute();
 
-        memberRepository.save(회원_정보_엔티티);
+        회원_생성_요청(회원_정보_DTO);
     }
 
     @DisplayName("Bearer Auth")
     @Test
     void bearerAuth() {
         TokenRequest 토큰_요청 = TokenRequest.builder()
-                .email(회원_정보_엔티티.getEmail())
-                .password(회원_정보_엔티티.getPassword())
+                .email(회원_정보_DTO.getEmail())
+                .password(회원_정보_DTO.getPassword())
                 .build();
 
         ExtractableResponse<Response> 토큰_응답 = RestAssuredClient.post("/login/token", 토큰_요청);

--- a/src/test/java/nextstep/support/RestAssuredClient.java
+++ b/src/test/java/nextstep/support/RestAssuredClient.java
@@ -64,6 +64,30 @@ public class RestAssuredClient {
 
     /**
      * <pre>
+     * path에 GET 방식으로
+     * RestAssured를 통해
+     * access token 정보를 담아
+     * HTTP 요청을 보낼 때 사용합니다.
+     * </pre>
+     *
+     * @param path
+     * @param accessToken
+     * @return ExtractableResponse
+     */
+    public static ExtractableResponse<Response> get(String path, String accessToken) {
+        return RestAssured
+                .given()
+                    .log().all()
+                    .auth().oauth2(accessToken)
+                .when()
+                    .get(path)
+                .then()
+                    .log().all()
+                    .extract();
+    }
+
+    /**
+     * <pre>
      * path에
      * GET 방식으로
      * RestAssured를 통해


### PR DESCRIPTION
안녕하세요, 리뷰어님!
리뷰 부탁드립니다 🙏

# 실습단계 코멘트에 따른 개선 사항

- [x] `AuthAcceptanceTest` 내에서 set up 단계에 회원 등록 API를 이용하도록 수정

# 기능 요구사항

- [x] 요구사항 설명에서 제공되는 추가된 요구사항을 기반으로 내 정보 조회 기능 구현
    - [x] url path가 아닌 header(authorization)을 이용하여 사용자 식별
- [x] 인수 조건을 도출하고 이를 검증하는 인수 테스트 작성

# 요구사항 설명
### Request

```
GET /members/me HTTP/1.1
authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjg3MDczNzcyLCJleHAiOjE2ODcwNzczNzIsInJvbGVzIjpbIlJPTEVfQURNSU4iLCJST0xFX0FETUlOIl19.1RtnNjTzhPg1uQejOdfBzpp2H0734KWjBFe59j5nZcM
accept: application/json
host: localhost:8080
```

### Response

```
HTTP/1.1 200 OK
Content-Type: application/json

{
    "id": 1,
    "email": "admin@email.com",
    "age": 20
}
```

# 기능 구현

- [x] `/members/me` 요청에 응답하는 메서드 구현