### PR TITLE
Step2 - 깃허브 로그인 구현

### DIFF
--- a/src/main/java/nextstep/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/exception/GlobalExceptionHandler.java
@@ -5,11 +5,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.naming.AuthenticationException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     protected ResponseEntity<Void> handleException(Exception e) {
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    protected ResponseEntity<Void> handleAuthenticationException(AuthenticationException e) {
+        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/nextstep/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/favorite/application/FavoriteService.java
@@ -66,9 +66,8 @@ public class FavoriteService {
     public void deleteFavorite(LoginMember loginMember, Long id) {
         Member member = memberRepository.findByEmail(loginMember.getEmail())
                 .orElseThrow(() -> new EntityNotFoundException("해당 이메일 계정을 찾을 수 없습니다."));
-        Favorite favorite = favoriteRepository.findById(id)
+        favoriteRepository.findByIdAndMemberId(id, member.getId())
                 .orElseThrow(() -> new EntityNotFoundException("해당 즐겨찾기를 찾을 수 없습니다."));
-        favorite.validate(member.getId());
 
         favoriteRepository.deleteById(id);
     }

--- a/src/main/java/nextstep/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/favorite/domain/Favorite.java
@@ -44,14 +44,4 @@ public class Favorite {
     public Long getTargetStationId() {
         return targetStationId;
     }
-
-    public void validate(Long memberId) {
-        if (!isOwner(memberId)) {
-            throw new IllegalArgumentException("해당 즐겨찾기 생성자가 아닙니다.");
-        }
-    }
-
-    private boolean isOwner(Long memberId) {
-        return this.memberId.equals(memberId);
-    }
 }

--- a/src/main/java/nextstep/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/favorite/domain/FavoriteRepository.java
@@ -3,7 +3,9 @@ package nextstep.favorite.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     List<Favorite> findAllByMemberId(Long memberId);
+    Optional<Favorite> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/nextstep/member/application/GithubClient.java
+++ b/src/main/java/nextstep/member/application/GithubClient.java
@@ -1,0 +1,64 @@
+package nextstep.member.application;
+
+import nextstep.member.application.dto.GithubAccessTokenRequest;
+import nextstep.member.application.dto.GithubAccessTokenResponse;
+import nextstep.member.application.dto.OAuth2ProfileResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GithubClient implements OAuth2Client{
+    @Value("${github.client-id}")
+    private String clientId;
+
+    @Value("${github.client-secret}")
+    private String clientSecret;
+
+    @Value("${github.url.access-token}")
+    private String accessTokenUrl;
+    @Value("${github.url.user}")
+    private String userUrl;
+
+    private final static String PREFIX = "bearer ";
+
+    @Override
+    public String requestGithubToken(String code) {
+        GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(
+                code,
+                clientId,
+                clientSecret
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(
+                githubAccessTokenRequest, headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        return restTemplate
+                .exchange(accessTokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
+                .getBody()
+                .getAccessToken();
+    }
+
+    @Override
+    public OAuth2ProfileResponse requestGithubProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.add(HttpHeaders.AUTHORIZATION, PREFIX + accessToken);
+
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        return restTemplate
+                .exchange(userUrl, HttpMethod.GET, httpEntity, OAuth2ProfileResponse.class)
+                .getBody();
+    }
+}

--- a/src/main/java/nextstep/member/application/MemberService.java
+++ b/src/main/java/nextstep/member/application/MemberService.java
@@ -2,19 +2,23 @@ package nextstep.member.application;
 
 import nextstep.member.application.dto.MemberRequest;
 import nextstep.member.application.dto.MemberResponse;
+import nextstep.member.application.dto.OAuth2ProfileResponse;
 import nextstep.member.domain.LoginMember;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class MemberService {
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     public MemberService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 
+    @Transactional
     public MemberResponse createMember(MemberRequest request) {
         Member member = memberRepository.save(request.toMember());
         return MemberResponse.of(member);
@@ -25,11 +29,13 @@ public class MemberService {
         return MemberResponse.of(member);
     }
 
+    @Transactional
     public void updateMember(Long id, MemberRequest param) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         member.update(param.toMember());
     }
 
+    @Transactional
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
     }
@@ -40,7 +46,17 @@ public class MemberService {
 
     public MemberResponse findMe(LoginMember loginMember) {
         return memberRepository.findByEmail(loginMember.getEmail())
-                .map(it -> MemberResponse.of(it))
+                .map(MemberResponse::of)
                 .orElseThrow(RuntimeException::new);
+    }
+
+    public Member findOrCreateMember(OAuth2ProfileResponse githubProfileResponse) {
+        return memberRepository.findByEmail(githubProfileResponse.getEmail())
+                .orElseGet(() -> memberRepository.save(
+                        new Member(
+                                githubProfileResponse.getEmail(),
+                                null,
+                                githubProfileResponse.getAge()))
+                );
     }
 }

--- a/src/main/java/nextstep/member/application/OAuth2Client.java
+++ b/src/main/java/nextstep/member/application/OAuth2Client.java
@@ -1,0 +1,8 @@
+package nextstep.member.application;
+
+import nextstep.member.application.dto.OAuth2ProfileResponse;
+
+public interface OAuth2Client {
+    String requestGithubToken(String code);
+    OAuth2ProfileResponse requestGithubProfile(String accessToken);
+}

--- a/src/main/java/nextstep/member/application/TokenService.java
+++ b/src/main/java/nextstep/member/application/TokenService.java
@@ -1,18 +1,23 @@
 package nextstep.member.application;
 
 import nextstep.member.AuthenticationException;
+import nextstep.member.application.dto.OAuth2ProfileResponse;
+import nextstep.member.application.dto.OAuth2LoginRequest;
 import nextstep.member.application.dto.TokenResponse;
 import nextstep.member.domain.Member;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 public class TokenService {
-    private MemberService memberService;
-    private JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final GithubClient githubClient;
 
-    public TokenService(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
+    public TokenService(MemberService memberService, JwtTokenProvider jwtTokenProvider, GithubClient githubClient) {
         this.memberService = memberService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.githubClient = githubClient;
     }
 
     public TokenResponse createToken(String email, String password) {
@@ -20,6 +25,20 @@ public class TokenService {
         if (!member.getPassword().equals(password)) {
             throw new AuthenticationException();
         }
+
+        String token = jwtTokenProvider.createToken(member.getEmail());
+
+        return new TokenResponse(token);
+    }
+
+    public TokenResponse createTokenByGithubLogin(OAuth2LoginRequest request) {
+        String accessToken = githubClient.requestGithubToken(request.getCode());
+        if (!StringUtils.hasText(accessToken)) {
+            throw new AuthenticationException();
+        }
+
+        OAuth2ProfileResponse profileResponse = githubClient.requestGithubProfile(accessToken);
+        Member member = memberService.findOrCreateMember(profileResponse);
 
         String token = jwtTokenProvider.createToken(member.getEmail());
 

--- a/src/main/java/nextstep/member/application/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/nextstep/member/application/dto/GithubAccessTokenRequest.java
@@ -1,0 +1,25 @@
+package nextstep.member.application.dto;
+
+public class GithubAccessTokenRequest {
+    private String code;
+    private String clientId;
+    private String clientSecret;
+
+    public GithubAccessTokenRequest(String code, String clientId, String clientSecret) {
+        this.code = code;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+}

--- a/src/main/java/nextstep/member/application/dto/GithubAccessTokenResponse.java
+++ b/src/main/java/nextstep/member/application/dto/GithubAccessTokenResponse.java
@@ -1,0 +1,27 @@
+package nextstep.member.application.dto;
+
+public class GithubAccessTokenResponse {
+    private String accessToken;
+    private String scope;
+    private String tokenType;
+
+    public GithubAccessTokenResponse() {}
+
+    public GithubAccessTokenResponse(String accessToken, String scope, String tokenType) {
+        this.accessToken = accessToken;
+        this.scope = scope;
+        this.tokenType = tokenType;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+}

--- a/src/main/java/nextstep/member/application/dto/OAuth2LoginRequest.java
+++ b/src/main/java/nextstep/member/application/dto/OAuth2LoginRequest.java
@@ -1,0 +1,15 @@
+package nextstep.member.application.dto;
+
+public class OAuth2LoginRequest {
+    private String code;
+
+    public OAuth2LoginRequest() {}
+
+    public OAuth2LoginRequest(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/nextstep/member/application/dto/OAuth2ProfileResponse.java
+++ b/src/main/java/nextstep/member/application/dto/OAuth2ProfileResponse.java
@@ -1,0 +1,20 @@
+package nextstep.member.application.dto;
+
+public class OAuth2ProfileResponse {
+    private String email;
+    private int age;
+
+    public OAuth2ProfileResponse() {}
+    public OAuth2ProfileResponse(String email, int age) {
+        this.email = email;
+        this.age = age;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}

--- a/src/main/java/nextstep/member/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/member/ui/AuthenticationPrincipalArgumentResolver.java
@@ -24,6 +24,9 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         String authorization = webRequest.getHeader("Authorization");
+        if (authorization == null) {
+            throw new AuthenticationException();
+        }
         if (!"bearer".equalsIgnoreCase(authorization.split(" ")[0])) {
             throw new AuthenticationException();
         }

--- a/src/main/java/nextstep/member/ui/TokenController.java
+++ b/src/main/java/nextstep/member/ui/TokenController.java
@@ -1,6 +1,7 @@
 package nextstep.member.ui;
 
 import nextstep.member.application.TokenService;
+import nextstep.member.application.dto.OAuth2LoginRequest;
 import nextstep.member.application.dto.TokenRequest;
 import nextstep.member.application.dto.TokenResponse;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class TokenController {
-    private TokenService tokenService;
+    private final TokenService tokenService;
 
     public TokenController(TokenService tokenService) {
         this.tokenService = tokenService;
@@ -19,6 +20,13 @@ public class TokenController {
     @PostMapping("/login/token")
     public ResponseEntity<TokenResponse> createToken(@RequestBody TokenRequest request) {
         TokenResponse response = tokenService.createToken(request.getEmail(), request.getPassword());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login/github")
+    public ResponseEntity<TokenResponse> getAccessToken(@RequestBody OAuth2LoginRequest request) {
+        TokenResponse response = tokenService.createTokenByGithubLogin(request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,8 @@ spring.jpa.properties.hibernate.format_sql=true
 
 security.jwt.token.secret-key= atdd-secret-key
 security.jwt.token.expire-length= 3600000
+
+github.client-id=client-id
+github.client-secret=client-secret
+github.url.access-token=https://github.com/github/login/oauth/access_token
+github.url.user=https://github.com/github/user

--- a/src/test/java/nextstep/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -24,14 +24,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("즐겨찾기 관련 기능")
 public class FavoriteAcceptanceTest extends AcceptanceTest {
+    private static final String email = "nextstep@gmail.com";
+    private static final String password = "1234";
     private Long 이호선;
     private Long 서초역;
     private Long 교대역;
     private Long 강남역;
     private Long 고속터미널역;
-
-    private String email = "nextstep@gmail.com";
-    private String password = "1234";
     private String accessToken;
 
     @BeforeEach

--- a/src/test/java/nextstep/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -112,7 +112,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     /**

--- a/src/test/java/nextstep/favorite/unit/FavoriteTest.java
+++ b/src/test/java/nextstep/favorite/unit/FavoriteTest.java
@@ -1,23 +1,4 @@
 package nextstep.favorite.unit;
 
-import nextstep.favorite.domain.Favorite;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 public class FavoriteTest {
-
-    /**
-    * when 즐겨찾기 생성자와 즐겨찾기 삭제 요청자가 다르면
-    * then IllegalArgumentException을 발생시킨다.
-    */
-
-    @DisplayName("즐겨찾기 생성자와 즐겨찾기 삭제요청자가 다르면 에러를 발생시킨다.")
-    @Test
-    void validateCreatorEqualRequester() {
-        Favorite favorite = new Favorite(1L, 1L, 1L, 2L);
-        Assertions.assertThatThrownBy(() -> favorite.validate(2L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 즐겨찾기 생성자가 아닙니다.");
-    }
 }

--- a/src/test/java/nextstep/member/acceptance/AuthSteps.java
+++ b/src/test/java/nextstep/member/acceptance/AuthSteps.java
@@ -1,0 +1,37 @@
+package nextstep.member.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.member.application.dto.OAuth2LoginRequest;
+import org.springframework.http.MediaType;
+
+public class AuthSteps {
+
+    public static ExtractableResponse<Response> 깃허브_토큰_발급(String code) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new OAuth2LoginRequest(code))
+                .when().post("/github/login/oauth/access_token")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 깃허브_정보_조회(String accessToken) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/github/user")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 깃허브_로그인_요청(String code) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new OAuth2LoginRequest(code))
+                .when().post("/login/github")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/nextstep/member/acceptance/GithubResponses.java
+++ b/src/test/java/nextstep/member/acceptance/GithubResponses.java
@@ -1,0 +1,60 @@
+package nextstep.member.acceptance;
+
+import java.util.Arrays;
+
+public enum GithubResponses {
+    사용자1("aofijeowifjaoief", "access_token_1", "email1@email.com", 20),
+    사용자2("fau3nfin93dmn", "access_token_2", "email2@email.com", 21),
+    사용자3("afnm93fmdodf", "access_token_3", "email3@email.com", 22),
+    사용자_X("fm04fndkaladmd", "", "", 0);
+
+    private final String code;
+    private final String accessToken;
+    private final String email;
+    private final int age;
+
+    GithubResponses(String code, String accessToken, String email, int age) {
+        this.code = code;
+        this.accessToken = accessToken;
+        this.email = email;
+        this.age = age;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public static String getAccessToken(String code) {
+        return Arrays.stream(GithubResponses.values())
+                .filter(member -> member.equalCode(code))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("올바르지 않은 요청입니다."))
+                .getAccessToken();
+    }
+
+    public static GithubResponses getResponse(String accessToken) {
+        return Arrays.stream(GithubResponses.values())
+                .filter(member -> member.equalAccessToken(accessToken))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("올바르지 않은 요청입니다."));
+    }
+
+    private boolean equalCode(String code) {
+        return this.code.equals(code);
+    }
+    private boolean equalAccessToken(String accessToken) {
+        return this.accessToken.equals(accessToken);
+    }
+}

--- a/src/test/java/nextstep/member/acceptance/GithubTestController.java
+++ b/src/test/java/nextstep/member/acceptance/GithubTestController.java
@@ -1,0 +1,28 @@
+package nextstep.member.acceptance;
+
+import nextstep.member.application.dto.GithubAccessTokenRequest;
+import nextstep.member.application.dto.GithubAccessTokenResponse;
+import nextstep.member.application.dto.OAuth2ProfileResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class GithubTestController {
+
+    @PostMapping("/github/login/oauth/access_token")
+    public ResponseEntity<GithubAccessTokenResponse> accessToken(
+            @RequestBody GithubAccessTokenRequest tokenRequest) {
+        String accessToken = GithubResponses.getAccessToken(tokenRequest.getCode());
+        GithubAccessTokenResponse response = new GithubAccessTokenResponse(accessToken, "", "");
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/github/user")
+    public ResponseEntity<OAuth2ProfileResponse> user(
+            @RequestHeader("Authorization") String authorization) {
+        String accessToken = authorization.split(" ")[1];
+        GithubResponses res = GithubResponses.getResponse(accessToken);
+        OAuth2ProfileResponse response = new OAuth2ProfileResponse(res.getEmail(), res.getAge());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/nextstep/member/application/GithubClientTest.java
+++ b/src/test/java/nextstep/member/application/GithubClientTest.java
@@ -1,0 +1,34 @@
+package nextstep.member.application;
+
+import nextstep.member.application.dto.OAuth2ProfileResponse;
+import nextstep.utils.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+import static nextstep.member.acceptance.GithubResponses.사용자1;
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+public class GithubClientTest extends AcceptanceTest {
+    @Autowired
+    private GithubClient githubClient;
+
+    @DisplayName("깃허브 accessToken 요청")
+    @Test
+    void requestGithubToken() {
+        String accessToken = githubClient.requestGithubToken(사용자1.getCode());
+
+       assertThat(accessToken).isEqualTo(사용자1.getAccessToken());
+    }
+
+    @DisplayName("깃허브 profile 요청")
+    @Test
+    void requestGithubProfile() {
+        OAuth2ProfileResponse res = githubClient.requestGithubProfile(사용자1.getAccessToken());
+
+        assertThat(res.getEmail()).isEqualTo(사용자1.getEmail());
+        assertThat(res.getAge()).isEqualTo(사용자1.getAge());
+    }
+}

--- a/src/test/java/nextstep/member/application/MemberServiceTest.java
+++ b/src/test/java/nextstep/member/application/MemberServiceTest.java
@@ -1,0 +1,46 @@
+package nextstep.member.application;
+
+import nextstep.member.application.dto.MemberRequest;
+import nextstep.member.application.dto.MemberResponse;
+import nextstep.member.application.dto.OAuth2ProfileResponse;
+import nextstep.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class MemberServiceTest {
+    private static final String EMAIL = "test@test.com";
+    private static final int AGE = 20;
+
+    @Autowired
+    private MemberService memberService;
+    private final static OAuth2ProfileResponse oAuth2ProfileResponse
+            = new OAuth2ProfileResponse(EMAIL, AGE);
+
+    @DisplayName("이미 회원이 존재한다면이라면 githubProfile 조회")
+    @Test
+    void findOrCreateMemberWhenMemberExist() {
+        MemberResponse memberResponse
+                = memberService.createMember(new MemberRequest(EMAIL, null, AGE));
+        Member member = memberService.findOrCreateMember(oAuth2ProfileResponse);
+
+        assertThat(memberResponse.getId()).isEqualTo(member.getId());
+    }
+
+    @DisplayName("존재하지 않는 회원이라면 회원 가입시킨 후 githubProfile 조회를 한다.")
+    @Test
+    void findOrCreateMemberWhenMemberNotExist() {
+        Member member = memberService.findOrCreateMember(oAuth2ProfileResponse);
+
+        assertThat(member.getId()).isNotNull();
+        assertThat(member.getEmail()).isEqualTo(EMAIL);
+        assertThat(member.getAge()).isEqualTo(AGE);
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+security.jwt.token.secret-key= atdd-secret-key
+security.jwt.token.expire-length= 3600000
+
+github.client-id=client-id
+github.client-secret=client-secret
+github.url.access-token=http://localhost:8080/github/login/oauth/access_token
+github.url.user=http://localhost:8080/github/user


### PR DESCRIPTION
안녕하세요 준우님! 2단계 리뷰 요청입니다.

1단계에서 요청해주신 수정사항들은 반영해두었습니다. 확인부탁드립니다!

인증 단계의 테스트 코드를 처음 구현해보는 것이라 모자란 부분이 많을 것이라 생각됩니다. 좋은 조언부탁드립니다.

아래는 1단계에서 질문주신 사항에 대한 답변입니다.
---
favorite를 간접참조로 구현한 이유가 있나요?
- 우선 해당 엔티티 내에서 member의 경우 명백히 aggregate root가 달라 간접참조를 하는 것이 맞다고 생각했습니다. 
- upStation과 downStation의 경우 직접참조 혹은 간접참조를 하여도 상관없다고 생각했습니다. favorite가 subway 도메인에 종속된다고 볼 수도 있고, aggregate root가 다르다고 볼 수도 있다고 생각했습니다. 
- 개인적으로는 subway 도메인내 다른 객체들을 호출할 때  favorite를 변경할 여지를 주지 않는 것이 더 좋다고 생각하여 간접참조로 구현하였습니다.
