### PR TITLE
🚀 2단계 - 깃헙 로그인 구현  🐈‍⬛

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ out/
 ### VS Code ###
 .vscode/
 frontend/node_modules
+
+application-auth.yml

--- a/src/main/java/nextstep/config/WebConfig.java
+++ b/src/main/java/nextstep/config/WebConfig.java
@@ -1,0 +1,14 @@
+package nextstep.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/nextstep/member/application/GithubOAuth2Service.java
+++ b/src/main/java/nextstep/member/application/GithubOAuth2Service.java
@@ -1,0 +1,50 @@
+package nextstep.member.application;
+
+import nextstep.member.application.dto.TokenResponse;
+import nextstep.member.domain.GithubOAuth2Client;
+import nextstep.member.domain.GithubOAuthProperty;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import nextstep.member.payload.AccessTokenRequest;
+import nextstep.member.payload.AccessTokenResponse;
+import nextstep.member.payload.GithubUserInfoResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class GithubOAuth2Service {
+
+    private final MemberRepository memberRepository;
+    private final GithubOAuth2Client githubOAuth2Client;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final GithubOAuthProperty githubOAuthProperty;
+
+
+    public GithubOAuth2Service(final MemberRepository memberRepository, final GithubOAuth2Client githubOAuth2Client, final JwtTokenProvider jwtTokenProvider, final GithubOAuthProperty githubOAuthProperty) {
+        this.memberRepository = memberRepository;
+        this.githubOAuth2Client = githubOAuth2Client;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.githubOAuthProperty = githubOAuthProperty;
+    }
+
+    public TokenResponse createToken(final String code) {
+        AccessTokenRequest accessTokenRequest = AccessTokenRequest.builder()
+                .clientId(githubOAuthProperty.getClientId())
+                .clientSecret(githubOAuthProperty.getClientSecret())
+                .code(code)
+                .build();
+
+        AccessTokenResponse accessToken = githubOAuth2Client.getAccessToken(accessTokenRequest);
+        GithubUserInfoResponse userInfo = githubOAuth2Client.getUserInfo(accessToken.getAccess_token());
+
+        Member member = memberRepository.findByEmail(userInfo.getEmail())
+                .orElseGet(() ->
+                        memberRepository.save(new Member(userInfo.getEmail()))
+                );
+
+        return new TokenResponse(jwtTokenProvider.createToken(member.getId(), member.getEmail()));
+    }
+
+}

--- a/src/main/java/nextstep/member/application/GithubOAuth2Service.java
+++ b/src/main/java/nextstep/member/application/GithubOAuth2Service.java
@@ -40,9 +40,7 @@ public class GithubOAuth2Service {
         GithubUserInfoResponse userInfo = githubOAuth2Client.getUserInfo(accessToken.getAccess_token());
 
         Member member = memberRepository.findByEmail(userInfo.getEmail())
-                .orElseGet(() ->
-                        memberRepository.save(new Member(userInfo.getEmail()))
-                );
+                .orElseGet(() -> memberRepository.save(new Member(userInfo.getEmail())));
 
         return new TokenResponse(jwtTokenProvider.createToken(member.getId(), member.getEmail()));
     }

--- a/src/main/java/nextstep/member/application/JwtTokenProvider.java
+++ b/src/main/java/nextstep/member/application/JwtTokenProvider.java
@@ -14,6 +14,14 @@ public class JwtTokenProvider {
     @Value("${security.jwt.token.expire-length}")
     private long validityInMilliseconds;
 
+    public JwtTokenProvider() {
+    }
+
+    public JwtTokenProvider(final String secretKey, final long validityInMilliseconds) {
+        this.secretKey = secretKey;
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
     public String createToken(final Long id, final String principal) {
         Claims claims = Jwts.claims().setSubject(principal);
         Date now = new Date();

--- a/src/main/java/nextstep/member/application/TokenService.java
+++ b/src/main/java/nextstep/member/application/TokenService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class TokenService {
-    private MemberService memberService;
-    private JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public TokenService(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
         this.memberService = memberService;

--- a/src/main/java/nextstep/member/domain/GithubOAuth2Client.java
+++ b/src/main/java/nextstep/member/domain/GithubOAuth2Client.java
@@ -1,0 +1,13 @@
+package nextstep.member.domain;
+
+import nextstep.member.payload.AccessTokenRequest;
+import nextstep.member.payload.AccessTokenResponse;
+import nextstep.member.payload.GithubUserInfoResponse;
+
+public interface GithubOAuth2Client {
+
+    AccessTokenResponse getAccessToken(AccessTokenRequest request);
+
+    GithubUserInfoResponse getUserInfo(String accessToken);
+
+}

--- a/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
+++ b/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
@@ -27,7 +27,6 @@ public class GithubOAuth2ClientImpl implements GithubOAuth2Client {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         HttpEntity<AccessTokenRequest> httpEntity = new HttpEntity<>(request, headers);
-
         return restTemplate.exchange(githubOAuthProperty.getTokenUrl(), HttpMethod.POST, httpEntity, AccessTokenResponse.class)
                 .getBody();
     }

--- a/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
+++ b/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
@@ -1,0 +1,20 @@
+package nextstep.member.domain;
+
+import nextstep.member.payload.AccessTokenRequest;
+import nextstep.member.payload.AccessTokenResponse;
+import nextstep.member.payload.GithubUserInfoResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GithubOAuth2ClientImpl implements GithubOAuth2Client {
+
+    @Override
+    public AccessTokenResponse getAccessToken(final AccessTokenRequest request) {
+        return null;
+    }
+
+    @Override
+    public GithubUserInfoResponse getUserInfo(final String accessToken) {
+        return null;
+    }
+}

--- a/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
+++ b/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
@@ -10,6 +10,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Map;
+
 @Component
 public class GithubOAuth2ClientImpl implements GithubOAuth2Client {
 
@@ -24,8 +26,7 @@ public class GithubOAuth2ClientImpl implements GithubOAuth2Client {
 
     @Override
     public AccessTokenResponse getAccessToken(final AccessTokenRequest request) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        HttpHeaders headers = createHeader(Map.of());
         HttpEntity<AccessTokenRequest> httpEntity = new HttpEntity<>(request, headers);
         return restTemplate.exchange(githubOAuthProperty.getTokenUrl(), HttpMethod.POST, httpEntity, AccessTokenResponse.class)
                 .getBody();
@@ -33,13 +34,17 @@ public class GithubOAuth2ClientImpl implements GithubOAuth2Client {
 
     @Override
     public GithubUserInfoResponse getUserInfo(final String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-        headers.add("Authorization", String.format("Bearer %s", accessToken));
+        HttpHeaders headers = createHeader(Map.of(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", accessToken)));
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-
         return restTemplate.exchange(githubOAuthProperty.getUserInfoUrl(), HttpMethod.GET, httpEntity, GithubUserInfoResponse.class)
                 .getBody();
+    }
+
+    private HttpHeaders createHeader(Map<String, String> additionalHeaders) {
+        HttpHeaders headers = new HttpHeaders();;
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        additionalHeaders.forEach(headers::add);
+        return headers;
     }
 
 }

--- a/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
+++ b/src/main/java/nextstep/member/domain/GithubOAuth2ClientImpl.java
@@ -3,18 +3,44 @@ package nextstep.member.domain;
 import nextstep.member.payload.AccessTokenRequest;
 import nextstep.member.payload.AccessTokenResponse;
 import nextstep.member.payload.GithubUserInfoResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 @Component
 public class GithubOAuth2ClientImpl implements GithubOAuth2Client {
 
+    private final RestTemplate restTemplate;
+
+    private final GithubOAuthProperty githubOAuthProperty;
+
+    public GithubOAuth2ClientImpl(final RestTemplate restTemplate, final GithubOAuthProperty githubOAuthProperty) {
+        this.restTemplate = restTemplate;
+        this.githubOAuthProperty = githubOAuthProperty;
+    }
+
     @Override
     public AccessTokenResponse getAccessToken(final AccessTokenRequest request) {
-        return null;
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<AccessTokenRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        return restTemplate.exchange(githubOAuthProperty.getTokenUrl(), HttpMethod.POST, httpEntity, AccessTokenResponse.class)
+                .getBody();
     }
 
     @Override
     public GithubUserInfoResponse getUserInfo(final String accessToken) {
-        return null;
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        headers.add("Authorization", String.format("Bearer %s", accessToken));
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(githubOAuthProperty.getUserInfoUrl(), HttpMethod.GET, httpEntity, GithubUserInfoResponse.class)
+                .getBody();
     }
+
 }

--- a/src/main/java/nextstep/member/domain/GithubOAuthProperty.java
+++ b/src/main/java/nextstep/member/domain/GithubOAuthProperty.java
@@ -1,0 +1,32 @@
+package nextstep.member.domain;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GithubOAuthProperty {
+    @Value("${oauth2.github.client-id}")
+    private String clientId;
+    @Value("${oauth2.github.client-secret}")
+    private String clientSecret;
+    @Value("${oauth2.github.user-info-uri}")
+    private String userInfoUrl;
+    @Value("${oauth2.github.token-uri}")
+    private String tokenUrl;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getUserInfoUrl() {
+        return userInfoUrl;
+    }
+
+    public String getTokenUrl() {
+        return tokenUrl;
+    }
+}

--- a/src/main/java/nextstep/member/domain/Member.java
+++ b/src/main/java/nextstep/member/domain/Member.java
@@ -1,6 +1,7 @@
 package nextstep.member.domain;
 
 import javax.persistence.*;
+import javax.persistence.criteria.CriteriaBuilder;
 import java.util.Objects;
 
 @Entity
@@ -20,6 +21,10 @@ public class Member {
         this.email = email;
         this.password = password;
         this.age = age;
+    }
+
+    public Member(String email) {
+        this.email = email;
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/member/domain/Member.java
+++ b/src/main/java/nextstep/member/domain/Member.java
@@ -1,7 +1,6 @@
 package nextstep.member.domain;
 
 import javax.persistence.*;
-import javax.persistence.criteria.CriteriaBuilder;
 import java.util.Objects;
 
 @Entity

--- a/src/main/java/nextstep/member/payload/AccessTokenRequest.java
+++ b/src/main/java/nextstep/member/payload/AccessTokenRequest.java
@@ -3,9 +3,9 @@ package nextstep.member.payload;
 
 public class AccessTokenRequest {
 
-    private final String client_id;
-    private final String client_secret;
-    private final String code;
+    private String client_id;
+    private String client_secret;
+    private String code;
 
     public String getClient_id() {
         return client_id;
@@ -15,8 +15,21 @@ public class AccessTokenRequest {
         return client_secret;
     }
 
+
     public String getCode() {
         return code;
+    }
+
+    public void setClient_id(final String client_id) {
+        this.client_id = client_id;
+    }
+
+    public void setClient_secret(final String client_secret) {
+        this.client_secret = client_secret;
+    }
+
+    public void setCode(final String code) {
+        this.code = code;
     }
 
     public static AuthorizeRequestBuilder builder() {

--- a/src/main/java/nextstep/member/payload/AccessTokenRequest.java
+++ b/src/main/java/nextstep/member/payload/AccessTokenRequest.java
@@ -1,0 +1,60 @@
+package nextstep.member.payload;
+
+
+public class AccessTokenRequest {
+
+    private final String client_id;
+    private final String client_secret;
+    private final String code;
+
+    public String getClient_id() {
+        return client_id;
+    }
+
+    public String getClient_secret() {
+        return client_secret;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public static AuthorizeRequestBuilder builder() {
+        return new AuthorizeRequestBuilder();
+    }
+
+    private AccessTokenRequest(final String client_id, final String client_secret, final String code) {
+        this.client_id = client_id;
+        this.client_secret = client_secret;
+        this.code = code;
+    }
+
+    public static class AuthorizeRequestBuilder {
+        private String clientId;
+        private String clientSecret;
+        private String code;
+
+
+        public AuthorizeRequestBuilder clientId(final String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public AuthorizeRequestBuilder clientSecret(final String clientSecret) {
+            this.clientSecret = clientSecret;
+            return this;
+        }
+
+        public AuthorizeRequestBuilder code(final String code) {
+            this.code = code;
+            return this;
+        }
+
+        public AccessTokenRequest build() {
+            return new AccessTokenRequest(clientId, clientSecret, code);
+        }
+
+    }
+
+
+}

--- a/src/main/java/nextstep/member/payload/AccessTokenResponse.java
+++ b/src/main/java/nextstep/member/payload/AccessTokenResponse.java
@@ -13,6 +13,10 @@ public class AccessTokenResponse {
     public AccessTokenResponse() {
     }
 
+    public AccessTokenResponse(final String access_token) {
+        this.access_token = access_token;
+    }
+
     public String getAccess_token() {
         return access_token;
     }

--- a/src/main/java/nextstep/member/payload/AccessTokenResponse.java
+++ b/src/main/java/nextstep/member/payload/AccessTokenResponse.java
@@ -1,0 +1,39 @@
+package nextstep.member.payload;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class AccessTokenResponse {
+    private String access_token;
+
+    @JsonIgnore
+    private String scope;
+    @JsonIgnore
+    private String token_type;
+
+    public AccessTokenResponse() {
+    }
+
+    public String getAccess_token() {
+        return access_token;
+    }
+
+    public void setAccess_token(final String access_token) {
+        this.access_token = access_token;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(final String scope) {
+        this.scope = scope;
+    }
+
+    public String getToken_type() {
+        return token_type;
+    }
+
+    public void setToken_type(final String token_type) {
+        this.token_type = token_type;
+    }
+}

--- a/src/main/java/nextstep/member/payload/GithubUserInfoResponse.java
+++ b/src/main/java/nextstep/member/payload/GithubUserInfoResponse.java
@@ -6,6 +6,14 @@ public class GithubUserInfoResponse {
 
     private String name;
 
+    public GithubUserInfoResponse() {
+    }
+
+    public GithubUserInfoResponse(final String email, final String name) {
+        this.email = email;
+        this.name = name;
+    }
+
     public String getEmail() {
         return email;
     }

--- a/src/main/java/nextstep/member/payload/GithubUserInfoResponse.java
+++ b/src/main/java/nextstep/member/payload/GithubUserInfoResponse.java
@@ -1,0 +1,16 @@
+package nextstep.member.payload;
+
+public class GithubUserInfoResponse {
+
+    private String email;
+
+    private String name;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/nextstep/member/ui/OAuth2Controller.java
+++ b/src/main/java/nextstep/member/ui/OAuth2Controller.java
@@ -1,0 +1,22 @@
+package nextstep.member.ui;
+
+import nextstep.member.application.GithubOAuth2Service;
+import nextstep.member.application.dto.TokenResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OAuth2Controller {
+
+    private final GithubOAuth2Service githubOAuth2Service;
+
+    public OAuth2Controller(final GithubOAuth2Service githubOAuth2Service) {
+        this.githubOAuth2Service = githubOAuth2Service;
+    }
+
+    @GetMapping("/login/code/github")
+    public ResponseEntity<TokenResponse> createToken(String code) {
+        return ResponseEntity.ok(githubOAuth2Service.createToken(code));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true
-
-security.jwt.token.secret-key= atdd-secret-key
-security.jwt.token.expire-length= 3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+  profiles:
+    include: auth
+
+oauth2:
+  github:
+    client-id: github-client-id
+    client-secret: github-client-secret
+    user-info-uri: https://api.github.com/user
+    token-uri: https://github.com/login/oauth/access_token
+
+security:
+  jwt:
+    token:
+      secret-key: atdd-secret-key
+      expire-length: 3600000

--- a/src/test/java/nextstep/line/acceptance/LineApiRequest.java
+++ b/src/test/java/nextstep/line/acceptance/LineApiRequest.java
@@ -9,7 +9,6 @@ import org.springframework.http.MediaType;
 
 public class LineApiRequest {
 
-
     public static Response 노선을_생성한다(final String name, final String color, final Long upStationId, final Long downStationId, final Long distance) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/member/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/AuthAcceptanceTest.java
@@ -1,7 +1,5 @@
 package nextstep.member.acceptance;
 
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
@@ -9,12 +7,9 @@ import nextstep.utils.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import static nextstep.member.acceptance.MemberApiRequest.내_정보를_조회한다;
+import static nextstep.member.acceptance.TokenApiRequest.토큰을_발급한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthAcceptanceTest extends AcceptanceTest {
@@ -30,26 +25,12 @@ class AuthAcceptanceTest extends AcceptanceTest {
     void bearerAuth() {
         memberRepository.save(new Member(EMAIL, PASSWORD, AGE));
 
-        Map<String, String> params = new HashMap<>();
-        params.put("email", EMAIL);
-        params.put("password", PASSWORD);
-
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
-                .when().post("/login/token")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value()).extract();
-
+        Response response = 토큰을_발급한다(EMAIL, PASSWORD);
         String accessToken = response.jsonPath().getString("accessToken");
         assertThat(accessToken).isNotBlank();
 
-        ExtractableResponse<Response> response2 = RestAssured.given().log().all()
-                .auth().oauth2(accessToken)
-                .when().get("/members/me")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value()).extract();
+        var 내정보 = 내_정보를_조회한다(accessToken);
 
-        assertThat(response2.jsonPath().getString("email")).isEqualTo(EMAIL);
+        assertThat(내정보.jsonPath().getString("email")).isEqualTo(EMAIL);
     }
 }

--- a/src/test/java/nextstep/member/acceptance/GithubOAuth2AcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/GithubOAuth2AcceptanceTest.java
@@ -1,0 +1,45 @@
+package nextstep.member.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import nextstep.utils.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static nextstep.member.acceptance.GithubOauth2ApiRequest.로그인_한다;
+import static nextstep.member.application.FakeGithubOAuth2Client.GithubResponses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GithubOAuth2AcceptanceTest extends AcceptanceTest {
+    private MemberRepository memberRepository;
+
+    @DisplayName("oauth2 인가된 email과 일치하는 유저가 존재하면 accessToken을 바로 반환한다")
+    @Test
+    void loginTest1() {
+        //Given 회원이 이미 존재할 때
+        var 회원1 = GithubResponses.사용자1;
+        memberRepository.save(new Member(회원1.getEmail(), "password", 19));
+
+        //When oauth2 로그인시
+        var accessToken = 로그인_한다(회원1.getCode()).jsonPath().getString("accessToken");
+
+        //Then accessToken 으로 로그인 할 수 있다.
+        ExtractableResponse<Response> response2 = RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .when().get("/members/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value()).extract();
+
+        assertThat(response2.jsonPath().getString("email")).isEqualTo(회원1.getEmail());
+    }
+
+    @DisplayName("oauth2 인가된 email과 일치하는 유저가 없으면 회원가입 후 accessToken을 바로 반환한다")
+    @Test
+    void loginTest2() {
+
+    }
+}

--- a/src/test/java/nextstep/member/acceptance/GithubOAuth2AcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/GithubOAuth2AcceptanceTest.java
@@ -5,16 +5,20 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
+import nextstep.member.ui.AuthenticationPrincipal;
 import nextstep.utils.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import static nextstep.member.acceptance.GithubOauth2ApiRequest.로그인_한다;
+import static nextstep.member.acceptance.MemberApiRequest.내_정보를_조회한다;
 import static nextstep.member.application.FakeGithubOAuth2Client.GithubResponses;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GithubOAuth2AcceptanceTest extends AcceptanceTest {
+    @Autowired
     private MemberRepository memberRepository;
 
     @DisplayName("oauth2 인가된 email과 일치하는 유저가 존재하면 accessToken을 바로 반환한다")
@@ -28,18 +32,20 @@ class GithubOAuth2AcceptanceTest extends AcceptanceTest {
         var accessToken = 로그인_한다(회원1.getCode()).jsonPath().getString("accessToken");
 
         //Then accessToken 으로 로그인 할 수 있다.
-        ExtractableResponse<Response> response2 = RestAssured.given().log().all()
-                .auth().oauth2(accessToken)
-                .when().get("/members/me")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value()).extract();
-
-        assertThat(response2.jsonPath().getString("email")).isEqualTo(회원1.getEmail());
+        Response 내_정보 = 내_정보를_조회한다(accessToken);
+        assertThat(내_정보.jsonPath().getString("email")).isEqualTo(회원1.getEmail());
     }
 
     @DisplayName("oauth2 인가된 email과 일치하는 유저가 없으면 회원가입 후 accessToken을 바로 반환한다")
     @Test
     void loginTest2() {
+        //Given 가입되지 않은 유저가
+        //When oauth2 로그인을 하면
+        var 회원1 = GithubResponses.사용자1;
+        var accessToken = 로그인_한다(회원1.getCode()).jsonPath().getString("accessToken");
 
+        //Then 내정보 조회시 생성된 계정정보를 확인할 수 있다
+        Response response2 = 내_정보를_조회한다(accessToken);
+        assertThat(response2.jsonPath().getString("email")).isEqualTo(회원1.getEmail());
     }
 }

--- a/src/test/java/nextstep/member/acceptance/GithubOauth2ApiRequest.java
+++ b/src/test/java/nextstep/member/acceptance/GithubOauth2ApiRequest.java
@@ -1,0 +1,20 @@
+package nextstep.member.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class GithubOauth2ApiRequest{
+
+    public static Response 로그인_한다(final String code) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .params(Map.of("code", code))
+                .basePath("/login/code/github")
+                .when().get()
+                .then().log().all()
+                .extract().response();
+    }
+}

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -63,7 +63,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    /**
+    /** TODO :
      * Given 회원 가입을 생성하고
      * And 로그인을 하고
      * When 토큰을 통해 내 정보를 조회하면
@@ -72,6 +72,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("내 정보를 조회한다.")
     @Test
     void getMyInfo() {
+        var createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
 
     }
 }

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -63,16 +63,4 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    /** TODO :
-     * Given 회원 가입을 생성하고
-     * And 로그인을 하고
-     * When 토큰을 통해 내 정보를 조회하면
-     * Then 내 정보를 조회할 수 있다
-     */
-    @DisplayName("내 정보를 조회한다.")
-    @Test
-    void getMyInfo() {
-        var createResponse = 회원_생성_요청(EMAIL, PASSWORD, AGE);
-
-    }
 }

--- a/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberAcceptanceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static nextstep.member.acceptance.MemberSteps.*;
+import static nextstep.member.acceptance.MemberApiRequest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MemberAcceptanceTest extends AcceptanceTest {

--- a/src/test/java/nextstep/member/acceptance/MemberApiRequest.java
+++ b/src/test/java/nextstep/member/acceptance/MemberApiRequest.java
@@ -3,6 +3,7 @@ package nextstep.member.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import java.util.HashMap;
@@ -10,7 +11,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MemberSteps {
+public class MemberApiRequest {
+
     public static ExtractableResponse<Response> 회원_생성_요청(String email, String password, Integer age) {
         Map<String, String> params = new HashMap<>();
         params.put("email", email);
@@ -64,4 +66,16 @@ public class MemberSteps {
         assertThat(response.jsonPath().getString("email")).isEqualTo(email);
         assertThat(response.jsonPath().getInt("age")).isEqualTo(age);
     }
+
+
+    public static Response 내_정보를_조회한다(final String accessToken) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .when().get("/members/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value()).extract()
+                .response();
+    }
+
+;
 }

--- a/src/test/java/nextstep/member/acceptance/MemberSteps.java
+++ b/src/test/java/nextstep/member/acceptance/MemberSteps.java
@@ -25,14 +25,14 @@ public class MemberSteps {
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 회원_정보_조회_요청(ExtractableResponse<Response> response) {
+    public static Response 회원_정보_조회_요청(ExtractableResponse<Response> response) {
         String uri = response.header("Location");
-
         return RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get(uri)
                 .then().log().all()
-                .extract();
+                .extract()
+                .response();
     }
 
     public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email, String password, Integer age) {
@@ -59,7 +59,7 @@ public class MemberSteps {
                 .then().log().all().extract();
     }
 
-    public static void 회원_정보_조회됨(ExtractableResponse<Response> response, String email, int age) {
+    public static void 회원_정보_조회됨(Response response, String email, int age) {
         assertThat(response.jsonPath().getString("id")).isNotNull();
         assertThat(response.jsonPath().getString("email")).isEqualTo(email);
         assertThat(response.jsonPath().getInt("age")).isEqualTo(age);

--- a/src/test/java/nextstep/member/acceptance/TokenApiRequest.java
+++ b/src/test/java/nextstep/member/acceptance/TokenApiRequest.java
@@ -1,0 +1,28 @@
+package nextstep.member.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TokenApiRequest {
+
+    public static Response 토큰을_발급한다(final String email, final String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/login/token")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value()).extract()
+                .response();
+    }
+
+
+}

--- a/src/test/java/nextstep/member/application/FakeGithubOAuth2Client.java
+++ b/src/test/java/nextstep/member/application/FakeGithubOAuth2Client.java
@@ -1,0 +1,70 @@
+package nextstep.member.application;
+
+import nextstep.member.domain.GithubOAuth2Client;
+import nextstep.member.payload.AccessTokenRequest;
+import nextstep.member.payload.AccessTokenResponse;
+import nextstep.member.payload.GithubUserInfoResponse;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@Primary
+public class FakeGithubOAuth2Client implements GithubOAuth2Client {
+
+    @Override
+    public AccessTokenResponse getAccessToken(final AccessTokenRequest request) {
+        GithubResponses githubResponses = GithubResponses.findByCode(request.getCode());
+        return new AccessTokenResponse(githubResponses.getAccessToken());
+    }
+
+    @Override
+    public GithubUserInfoResponse getUserInfo(final String accessToken) {
+        GithubResponses githubResponses = GithubResponses.findByAccessToken(accessToken);
+        return new GithubUserInfoResponse(githubResponses.getEmail(), githubResponses.name());
+    }
+
+    public enum GithubResponses {
+        사용자1("aofijeowifjaoief", "access_token_1", "email1@email.com"),
+        사용자2("fau3nfin93dmn", "access_token_2", "email2@email.com"),
+        사용자3("afnm93fmdodf", "access_token_3", "email3@email.com"),
+        사용자4("fm04fndkaladmd", "access_token_4", "email4@email.com");
+
+        private final String code;
+        private final String accessToken;
+        private final String email;
+
+        GithubResponses(final String code, final String accessToken, final String email) {
+            this.code = code;
+            this.accessToken = accessToken;
+            this.email = email;
+        }
+
+        public static GithubResponses findByCode(String code) {
+            return Arrays.stream(GithubResponses.values())
+                    .filter(it -> it.code.equals(code))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("code 정보가 유효하지 않습니다"));
+        }
+
+        public static GithubResponses findByAccessToken(String accessToken) {
+            return Arrays.stream(GithubResponses.values())
+                    .filter(it -> it.accessToken.equals(accessToken))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("accessToken 정보가 유효하지 않습니다"));
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+    }
+}

--- a/src/test/java/nextstep/member/application/GithubOAuth2ServiceTest.java
+++ b/src/test/java/nextstep/member/application/GithubOAuth2ServiceTest.java
@@ -1,0 +1,71 @@
+package nextstep.member.application;
+
+import nextstep.member.application.FakeGithubOAuth2Client.GithubResponses;
+import nextstep.member.domain.GithubOAuth2Client;
+import nextstep.member.domain.GithubOAuthProperty;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class GithubOAuth2ServiceTest {
+
+    private GithubOAuth2Service githubOAuth2Service;
+
+    private MemberRepository memberRepository;
+    private GithubOAuth2Client githubOAuth2Client;
+    private JwtTokenProvider jwtTokenProvider;
+    private GithubOAuthProperty githubOAuthProperty;
+
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(MemberRepository.class);
+        githubOAuth2Client = new FakeGithubOAuth2Client();
+        jwtTokenProvider = new JwtTokenProvider("test-secret-key", 360000);
+        githubOAuthProperty = mock(GithubOAuthProperty.class);
+
+        githubOAuth2Service = new GithubOAuth2Service(memberRepository, githubOAuth2Client, jwtTokenProvider, githubOAuthProperty);
+    }
+
+
+    @DisplayName("기존에 회원이 있으면 email이 일치하는 회원을 찾아 accessToken을 발행한다")
+    @Test
+    void whenMemberExistThenReturnAccessToken() {
+        //Given 기존에 회원이 있으면
+        var 회원1 = GithubResponses.사용자1;
+        when(memberRepository.findByEmail(회원1.getEmail()))
+                .thenReturn(Optional.of(new Member(회원1.getEmail())));
+
+        //Then email이 일치하는 회원을 찾아 accessToken을 발행한다
+        githubOAuth2Service.createToken(회원1.getCode()).getAccessToken();
+
+        //Then 회원 생성 로직은 실행되지 않는다
+        verify(memberRepository, times(0)).save(new Member(회원1.getEmail()));
+
+    }
+
+    @DisplayName("기존에 회원이 없으면 member 생성후 accessToken을 발행한다")
+    @Test
+    void whenMemberNonExistThenCreateMemberThenReturnAccessToken() {
+        //Given 기존에 회원이 없으면
+        var 회원1 = GithubResponses.사용자1;
+        when(memberRepository.findByEmail(회원1.getEmail()))
+                .thenReturn(Optional.empty());
+
+        when(memberRepository.save(any(Member.class)))
+                .thenReturn(new Member(회원1.getEmail()));
+
+        //When 요청시
+        githubOAuth2Service.createToken(회원1.getCode());
+
+        //Then 회원 생성 로직이 실행된다
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+
+}


### PR DESCRIPTION
안녕하세요 리뷰어님~ 2단계 서둘러 진행해 보았습니다.

아래는 미션하면서 고려했던 내용입니다.

1. 이번 미션은 원래 [깃헙 대신 다른 곳으로 요청 보내기] 미션이 있었는데요
저저번주 수업내용에서 강사님께서 이부분에대해서 말씀을 주셨는데
제가 fake controller를 만드는 대신 실제로 api 호출이 이루어지는 부분만 추상화해도 되지 않을까요? 하는 질문에
자유롭게 해보라고 하셔서 저는 FakeClient 객체를 만드는걸로 테스트 구현을 해보았습니다

2. 다른 벤더사까지 고려하여 추상화 수준을 올려볼까? age값은 받아올 수 없는데 이것까지 만들어볼까? 
하다가 oauth2 Member 까지 만들면 시간이 너무 오래걸릴거 같아서 age는 받지 않는걸로 만들었습니다

3. 스프링이 제공해주는 ConfigurationProperties 인 OAuth2ClientProperties 쓰려다가 코드가 너무 더러워져서 그냥 자체    GithubOAuthProperty를 만드는걸로 대신했습니다. 실제 GithubOAuth2ClientImpl 구현체를 사용했을 때 github 요청도 잘 되는 부분까지 확인하고 제출합니다.

잘부탁드립니다. 
감사합니다.