### PR TITLE
2단계 - 깃헙 로그인 구현

### DIFF
--- a/src/main/java/nextstep/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/favorite/application/FavoriteService.java
@@ -67,7 +67,7 @@ public class FavoriteService {
 
         List<Section> sections = sectionRepository.findAll();
         SubwayGraph subwayGraph = new SubwayGraph(sections);
-        DijkstraShortestPath shortestPath = subwayGraph.getShortestPath();
+        DijkstraShortestPath shortestPath = subwayGraph.getDijkstraShortestPath();
         try {
             shortestPath.getPath(sourceId, targetId);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/nextstep/global/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/global/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package nextstep.global;
 
 import nextstep.global.exception.AlreadyRegisteredException;
+import nextstep.global.exception.GithubConnectionFailException;
 import nextstep.global.exception.InsufficientStationException;
 import nextstep.global.exception.SectionMismatchException;
 import nextstep.global.exception.StationNotMatchException;
@@ -17,7 +18,8 @@ public class GlobalExceptionHandler {
             AlreadyRegisteredException.class,
             InsufficientStationException.class,
             StationNotMatchException.class,
-            IllegalArgumentException.class
+            IllegalArgumentException.class,
+            GithubConnectionFailException.class
     })
     public ResponseEntity<ErrorResponse> handleBadRequestException(RuntimeException e) {
         return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.BAD_REQUEST);

--- a/src/main/java/nextstep/global/exception/GithubConnectionFailException.java
+++ b/src/main/java/nextstep/global/exception/GithubConnectionFailException.java
@@ -1,0 +1,10 @@
+package nextstep.global.exception;
+
+public class GithubConnectionFailException extends RuntimeException {
+
+    private static final String MESSAGE = "Github 응답이 없습니다";
+
+    public GithubConnectionFailException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/nextstep/member/application/GithubClient.java
+++ b/src/main/java/nextstep/member/application/GithubClient.java
@@ -1,0 +1,63 @@
+package nextstep.member.application;
+
+import nextstep.global.exception.AuthenticationException;
+import nextstep.global.exception.GithubConnectionFailException;
+import nextstep.member.application.dto.GithubAccessTokenRequest;
+import nextstep.member.application.dto.GithubAccessTokenResponse;
+import nextstep.member.config.GithubProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GithubClient {
+
+    private static final String ACCESS_TOKEN_URL = "/github/login/oauth/access_token";
+
+    private final GithubProperties githubProperties;
+    private final RestTemplate restTemplate;
+
+    public GithubClient(GithubProperties githubProperties) {
+        this.githubProperties = githubProperties;
+        this.restTemplate = new RestTemplateBuilder()
+                .rootUri(githubProperties.getUrl())
+                .defaultHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
+                .messageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    public String requestGithubToken(String code) {
+        var body = GithubAccessTokenRequest.of(
+                code,
+                githubProperties.getClientId(),
+                githubProperties.getClientSecret()
+        );
+        var httpEntity = new HttpEntity<>(body);
+        var response = restTemplate.exchange(
+                        ACCESS_TOKEN_URL,
+                        HttpMethod.POST,
+                        httpEntity,
+                        GithubAccessTokenResponse.class
+                ).getBody();
+
+        validateGithubResponse(response);
+        validateToken(response.getAccessToken());
+        return response.getAccessToken();
+    }
+
+    private void validateGithubResponse(GithubAccessTokenResponse response) {
+        if (response == null) {
+            throw new GithubConnectionFailException();
+        }
+    }
+
+    private void validateToken(String token) {
+        if (token == null || token.isBlank()) {
+            throw new AuthenticationException();
+        }
+    }
+}

--- a/src/main/java/nextstep/member/application/GithubClient.java
+++ b/src/main/java/nextstep/member/application/GithubClient.java
@@ -4,9 +4,11 @@ import nextstep.global.exception.AuthenticationException;
 import nextstep.global.exception.GithubConnectionFailException;
 import nextstep.member.application.dto.GithubAccessTokenRequest;
 import nextstep.member.application.dto.GithubAccessTokenResponse;
+import nextstep.member.application.dto.GithubProfileResponse;
 import nextstep.member.config.GithubProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -17,6 +19,7 @@ import org.springframework.web.client.RestTemplate;
 public class GithubClient {
 
     private static final String ACCESS_TOKEN_URL = "/github/login/oauth/access_token";
+    private static final String PROFILE_URL = "/github/user";
 
     private final GithubProperties githubProperties;
     private final RestTemplate restTemplate;
@@ -47,6 +50,19 @@ public class GithubClient {
         validateGithubResponse(response);
         validateToken(response.getAccessToken());
         return response.getAccessToken();
+    }
+
+    public GithubProfileResponse requestUserProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " +accessToken);
+
+        var httpEntity = new HttpEntity<>(null, headers);
+        return restTemplate.exchange(
+                PROFILE_URL,
+                HttpMethod.GET,
+                httpEntity,
+                GithubProfileResponse.class
+        ).getBody();
     }
 
     private void validateGithubResponse(GithubAccessTokenResponse response) {

--- a/src/main/java/nextstep/member/application/MemberService.java
+++ b/src/main/java/nextstep/member/application/MemberService.java
@@ -20,6 +20,10 @@ public class MemberService {
         return MemberResponse.of(member);
     }
 
+    public Member createMember(String email, String password, Integer age) {
+        return memberRepository.save(new Member(email, password, age));
+    }
+
     public MemberResponse findMember(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         return MemberResponse.of(member);
@@ -42,5 +46,12 @@ public class MemberService {
         return memberRepository.findByEmail(loginMember.getEmail())
                 .map(it -> MemberResponse.of(it))
                 .orElseThrow(RuntimeException::new);
+    }
+
+    public Member findMemberByEmailOrCreate(String email, Integer age) {
+        String defaultPassword = "password";
+
+        return memberRepository.findByEmail(email)
+                .orElseGet(() -> createMember(email, defaultPassword, age));
     }
 }

--- a/src/main/java/nextstep/member/application/TokenService.java
+++ b/src/main/java/nextstep/member/application/TokenService.java
@@ -27,7 +27,10 @@ public class TokenService {
     }
 
     public TokenResponse createTokenFromGithub(GithubTokenRequest request) {
-        String token = githubClient.requestGithubToken(request.getCode());
-        return new TokenResponse(token);
+        var token = githubClient.requestGithubToken(request.getCode());
+        var githubProfileResponse = githubClient.requestUserProfile(token);
+        Member member = memberService.findMemberByEmailOrCreate(githubProfileResponse.getEmail(),
+                githubProfileResponse.getAge());
+        return createToken(member.getEmail(), member.getPassword());
     }
 }

--- a/src/main/java/nextstep/member/application/TokenService.java
+++ b/src/main/java/nextstep/member/application/TokenService.java
@@ -1,19 +1,19 @@
 package nextstep.member.application;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.global.exception.AuthenticationException;
+import nextstep.member.application.dto.GithubTokenRequest;
 import nextstep.member.application.dto.TokenResponse;
 import nextstep.member.domain.Member;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
 @Service
 public class TokenService {
-    private MemberService memberService;
-    private JwtTokenProvider jwtTokenProvider;
 
-    public TokenService(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
-        this.memberService = memberService;
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final GithubClient githubClient;
 
     public TokenResponse createToken(String email, String password) {
         Member member = memberService.findMemberByEmail(email);
@@ -23,6 +23,11 @@ public class TokenService {
 
         String token = jwtTokenProvider.createToken(member.getEmail());
 
+        return new TokenResponse(token);
+    }
+
+    public TokenResponse createTokenFromGithub(GithubTokenRequest request) {
+        String token = githubClient.requestGithubToken(request.getCode());
         return new TokenResponse(token);
     }
 }

--- a/src/main/java/nextstep/member/application/dto/GithubAccessTokenRequest.java
+++ b/src/main/java/nextstep/member/application/dto/GithubAccessTokenRequest.java
@@ -1,0 +1,27 @@
+package nextstep.member.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GithubAccessTokenRequest {
+
+    private String code;
+    private String clientId;
+    private String clientSecret;
+
+    @Builder
+    private GithubAccessTokenRequest(String code, String clientId, String clientSecret) {
+        this.code = code;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public static GithubAccessTokenRequest of(String code, String clientId, String clientSecret) {
+        return GithubAccessTokenRequest.builder()
+                .code(code)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build();
+    }
+}

--- a/src/main/java/nextstep/member/application/dto/GithubAccessTokenResponse.java
+++ b/src/main/java/nextstep/member/application/dto/GithubAccessTokenResponse.java
@@ -1,0 +1,17 @@
+package nextstep.member.application.dto;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class GithubAccessTokenResponse {
+
+    private String accessToken;
+
+    public GithubAccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+}

--- a/src/main/java/nextstep/member/application/dto/GithubProfileResponse.java
+++ b/src/main/java/nextstep/member/application/dto/GithubProfileResponse.java
@@ -1,0 +1,32 @@
+package nextstep.member.application.dto;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class GithubProfileResponse {
+
+    private String email;
+    private Integer age;
+
+    @Builder
+    private GithubProfileResponse(String email, Integer age) {
+        this.email = email;
+        this.age = age;
+    }
+
+    public static GithubProfileResponse of(String email, Integer age) {
+        return GithubProfileResponse.builder()
+                .email(email)
+                .age(age)
+                .build();
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+}

--- a/src/main/java/nextstep/member/application/dto/GithubTokenRequest.java
+++ b/src/main/java/nextstep/member/application/dto/GithubTokenRequest.java
@@ -1,0 +1,17 @@
+package nextstep.member.application.dto;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class GithubTokenRequest {
+
+    private String code;
+
+    public GithubTokenRequest(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/nextstep/member/config/GithubProperties.java
+++ b/src/main/java/nextstep/member/config/GithubProperties.java
@@ -1,0 +1,19 @@
+package nextstep.member.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+public class GithubProperties {
+
+    @Value("${github.url}")
+    private String url;
+    @Value("${github.clientId}")
+    private String clientId;
+    @Value("${github.clientSecret}")
+    private String clientSecret;
+}

--- a/src/main/java/nextstep/member/domain/GithubResponse.java
+++ b/src/main/java/nextstep/member/domain/GithubResponse.java
@@ -1,0 +1,31 @@
+package nextstep.member.domain;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum GithubResponse {
+
+    사용자1("aofijeowifjaoief", "access_token_1", "email1@email.com"),
+    사용자2("fau3nfin93dmn", "access_token_2", "email2@email.com"),
+    사용자3("afnm93fmdodf", "access_token_3", "email3@email.com"),
+    사용자4("fm04fndkaladmd", "access_token_4", "email4@email.com");
+
+    private String code;
+    private String accessToken;
+    private String email;
+
+    GithubResponse(String code, String accessToken, String email) {
+        this.code = code;
+        this.accessToken = accessToken;
+        this.email = email;
+    }
+
+    public static String getAccessTokenByCode(String code) {
+        return Arrays.stream(GithubResponse.values())
+                .filter(x -> x.getCode().equals(code))
+                .map(GithubResponse::getAccessToken)
+                .findAny().get();
+    }
+
+}

--- a/src/main/java/nextstep/member/domain/GithubResponse.java
+++ b/src/main/java/nextstep/member/domain/GithubResponse.java
@@ -28,4 +28,11 @@ public enum GithubResponse {
                 .findAny().get();
     }
 
+    public static String getEmailByAccessToken(String accessToken) {
+        return Arrays.stream(GithubResponse.values())
+                .filter(x -> x.getAccessToken().equals(accessToken))
+                .map(GithubResponse::getEmail)
+                .findAny().get();
+    }
+
 }

--- a/src/main/java/nextstep/member/ui/TokenController.java
+++ b/src/main/java/nextstep/member/ui/TokenController.java
@@ -1,6 +1,7 @@
 package nextstep.member.ui;
 
 import nextstep.member.application.TokenService;
+import nextstep.member.application.dto.GithubTokenRequest;
 import nextstep.member.application.dto.TokenRequest;
 import nextstep.member.application.dto.TokenResponse;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,13 @@ public class TokenController {
     @PostMapping("/login/token")
     public ResponseEntity<TokenResponse> createToken(@RequestBody TokenRequest request) {
         TokenResponse response = tokenService.createToken(request.getEmail(), request.getPassword());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login/github")
+    public ResponseEntity<TokenResponse> getGithubToken(@RequestBody GithubTokenRequest request) {
+        TokenResponse response = tokenService.createTokenFromGithub(request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/nextstep/subway/path/api/PathService.java
+++ b/src/main/java/nextstep/subway/path/api/PathService.java
@@ -5,13 +5,12 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import nextstep.subway.path.api.response.PathResponse;
 import nextstep.subway.path.domain.SubwayGraph;
+import nextstep.subway.path.domain.ShortestPath;
 import nextstep.subway.section.SectionRepository;
 import nextstep.subway.section.domain.Section;
 import nextstep.subway.station.Station;
 import nextstep.subway.station.StationRepository;
 import nextstep.subway.station.StationResponse;
-import org.jgrapht.GraphPath;
-import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityNotFoundException;
@@ -48,20 +47,9 @@ public class PathService {
     public PathResponse findPath(Long sourceId, Long targetId) {
         List<Section> sections = sectionRepository.findAll();
         SubwayGraph subwayGraph = new SubwayGraph(sections);
-        DijkstraShortestPath dijkstraShortestPath = subwayGraph.getShortestPath();
-        GraphPath shortestPath = null;
+        ShortestPath shortestPath = new ShortestPath(subwayGraph.getDijkstraShortestPath(), sourceId, targetId);
 
-        try {
-            shortestPath = dijkstraShortestPath.getPath(sourceId, targetId);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("출발역과 종착역이 연결되어 있지 않습니다.");
-        }
-
-        if (shortestPath.getWeight() == 0) {
-            throw new IllegalArgumentException("출발역과 종착역이 같습니다.");
-        }
-
-        return PathResponse.of(convertToStationResponses(shortestPath.getVertexList()), (int) shortestPath.getWeight());
+        return PathResponse.of(convertToStationResponses(shortestPath.getVertexList()), shortestPath.getWeight());
     }
 
     private List<StationResponse> convertToStationResponses(List<Long> stationIds) {

--- a/src/main/java/nextstep/subway/path/domain/ShortestPath.java
+++ b/src/main/java/nextstep/subway/path/domain/ShortestPath.java
@@ -1,0 +1,41 @@
+package nextstep.subway.path.domain;
+
+import java.util.List;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+
+public class ShortestPath {
+
+    private GraphPath path;
+
+    public ShortestPath(DijkstraShortestPath dijkstraShortestPath, Long sourceId, Long targetId) {
+        this.path = createPath(dijkstraShortestPath, sourceId, targetId);
+    }
+
+    private GraphPath createPath(DijkstraShortestPath dijkstraShortestPath, Long sourceId, Long targetId) {
+        try {
+            path = dijkstraShortestPath.getPath(sourceId, targetId);
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("출발역과 종착역이 연결되어 있지 않습니다.");
+        }
+
+        if (path == null) {
+            throw new IllegalArgumentException("출발역과 종착역이 연결되어 있지 않습니다.");
+        }
+
+        if (path.getWeight() == 0) {
+            throw new IllegalArgumentException("출발역과 종착역이 같습니다.");
+        }
+
+        return path;
+    }
+
+    public List<Long> getVertexList() {
+        return path.getVertexList();
+    }
+
+    public int getWeight() {
+        return (int) path.getWeight();
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/SubwayGraph.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayGraph.java
@@ -14,7 +14,7 @@ public class SubwayGraph {
         this.graph = createGraph(sections);
     }
 
-    public DijkstraShortestPath getShortestPath() {
+    public DijkstraShortestPath getDijkstraShortestPath() {
         return new DijkstraShortestPath(graph);
     }
 

--- a/src/main/java/nextstep/subway/section/presentation/SectionController.java
+++ b/src/main/java/nextstep/subway/section/presentation/SectionController.java
@@ -1,7 +1,6 @@
 package nextstep.subway.section.presentation;
 
 import lombok.RequiredArgsConstructor;
-import nextstep.subway.path.api.PathService;
 import nextstep.subway.section.api.SectionService;
 import nextstep.subway.section.api.response.SectionResponse;
 import nextstep.subway.section.presentation.request.SectionCreateRequest;
@@ -15,7 +14,6 @@ import java.net.URI;
 public class SectionController {
 
     private final SectionService sectionService;
-    private final PathService pathService;
 
     @PostMapping("/lines/{lineId}/sections")
     public ResponseEntity<SectionResponse> createSection(@PathVariable Long lineId, @RequestBody SectionCreateRequest request) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 security.jwt.token.secret-key= atdd-secret-key
 security.jwt.token.expire-length= 3600000
+
+github.url = https://github.com
+github.clientId = test_id
+github.clientSecret = test_secret

--- a/src/test/java/nextstep/member/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/member/acceptance/AuthAcceptanceTest.java
@@ -2,6 +2,7 @@ package nextstep.member.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.member.application.dto.GithubTokenRequest;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import nextstep.utils.AcceptanceTest;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+import static nextstep.member.acceptance.AuthSteps.깃헙_로그인_요청;
 import static nextstep.member.acceptance.AuthSteps.로그인_토큰발급_요청;
 import static nextstep.member.acceptance.MemberSteps.유저조회_요청;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +20,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "admin@email.com";
     public static final String PASSWORD = "password";
     public static final Integer AGE = 20;
+    public static final String 사용자1_CODE = "aofijeowifjaoief";
 
     @Autowired
     private MemberRepository memberRepository;
@@ -35,5 +38,18 @@ class AuthAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> memberInfoResponse = 유저조회_요청(accessToken);
         assertThat(memberInfoResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(memberInfoResponse.jsonPath().getString("email")).isEqualTo(EMAIL);
+    }
+
+    @DisplayName("Github Auth")
+    @Test
+    void 깃헙_로그인을_구현한다() {
+        // given
+        GithubTokenRequest request = new GithubTokenRequest(사용자1_CODE);
+
+        // when
+        ExtractableResponse<Response> response = 깃헙_로그인_요청(request);
+
+        // then
+        assertThat(response.jsonPath().getString("accessToken")).isNotBlank();
     }
 }

--- a/src/test/java/nextstep/member/acceptance/AuthSteps.java
+++ b/src/test/java/nextstep/member/acceptance/AuthSteps.java
@@ -5,6 +5,8 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
+import nextstep.member.application.dto.GithubTokenRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 public class AuthSteps {
@@ -24,5 +26,14 @@ public class AuthSteps {
 
     public static String 로그인_토큰발급_요청_후_토큰_반환(String email, String password) {
         return 로그인_토큰발급_요청(email, password).jsonPath().getString("accessToken");
+    }
+
+    public static ExtractableResponse<Response> 깃헙_로그인_요청(GithubTokenRequest request) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/login/github")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value()).extract();
     }
 }

--- a/src/test/java/nextstep/member/application/GithubClientTest.java
+++ b/src/test/java/nextstep/member/application/GithubClientTest.java
@@ -1,0 +1,32 @@
+package nextstep.member.application;
+
+import static nextstep.member.domain.GithubResponse.사용자1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("test")
+public class GithubClientTest {
+
+    @Autowired
+    GithubClient githubClient;
+
+    @Test
+    void 토큰_요청을_보낸다() {
+        // given
+        String 사용자1_code = 사용자1.getCode();
+        String 사용자1_access_token = 사용자1.getAccessToken();
+
+        // when
+        String actual = githubClient.requestGithubToken(사용자1_code);
+
+        // then
+        assertThat(actual).isNotBlank();
+        assertThat(actual).isEqualTo(사용자1_access_token);
+    }
+}

--- a/src/test/java/nextstep/member/application/GithubClientTest.java
+++ b/src/test/java/nextstep/member/application/GithubClientTest.java
@@ -29,4 +29,15 @@ public class GithubClientTest {
         assertThat(actual).isNotBlank();
         assertThat(actual).isEqualTo(사용자1_access_token);
     }
+
+    @Test
+    void 토큰으로_유저프로필을_응답받는다() {
+        var accessToken = 사용자1.getAccessToken();
+        var 사용자1_email = 사용자1.getEmail();
+
+        var result = githubClient.requestUserProfile(accessToken);
+
+        assertThat(result.getEmail()).isEqualTo(사용자1_email);
+        assertThat(result.getAge()).isEqualTo(20);
+    }
 }

--- a/src/test/java/nextstep/member/presentation/TestController.java
+++ b/src/test/java/nextstep/member/presentation/TestController.java
@@ -1,0 +1,20 @@
+package nextstep.member.presentation;
+
+import nextstep.member.application.dto.GithubAccessTokenRequest;
+import nextstep.member.application.dto.GithubAccessTokenResponse;
+import nextstep.member.domain.GithubResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @PostMapping("/github/login/oauth/access_token")
+    public ResponseEntity<GithubAccessTokenResponse> accessToken(@RequestBody GithubAccessTokenRequest tokenRequest) {
+        var accessToken = GithubResponse.getAccessTokenByCode(tokenRequest.getCode());
+        var response = new GithubAccessTokenResponse(accessToken);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/nextstep/member/presentation/TestController.java
+++ b/src/test/java/nextstep/member/presentation/TestController.java
@@ -2,10 +2,13 @@ package nextstep.member.presentation;
 
 import nextstep.member.application.dto.GithubAccessTokenRequest;
 import nextstep.member.application.dto.GithubAccessTokenResponse;
+import nextstep.member.application.dto.GithubProfileResponse;
 import nextstep.member.domain.GithubResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,4 +20,14 @@ public class TestController {
         var response = new GithubAccessTokenResponse(accessToken);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/github/user")
+    public ResponseEntity<GithubProfileResponse> user(
+            @RequestHeader("Authorization") String authorization) {
+        var accessToken = authorization.split(" ")[1];
+        var email = GithubResponse.getEmailByAccessToken(accessToken);
+        var response = GithubProfileResponse.of(email, 20);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+security.jwt.token.secret-key= atdd-secret-key
+security.jwt.token.expire-length= 3600000
+
+github.url = http://localhost:8080
+github.clientId = test_id
+github.clientSecret = test_secret


### PR DESCRIPTION
날이 쌀쌀해졌네요 성현님~

2단계 리뷰 요청드립니다. 

진행하며 몇 가지 질문이 있습니다. 
Q) GithubClient 클래스의 패키지 위치와 컴포넌트 어노테이션이 적절한지 궁금합니다. 처음엔 member 패키지 안에 config 패키지를 만들고 그 안에 위치시켰습니다. 고민해보니 request요청이 application 패키지 내에 위치하는게 더 적절해보여서 옮기게 되었는데, application 패키지 안에 두면 @Service 어노테이션이 더 맞는건가 고민도 되더라구요. 

Q) MemberService에 findMemberByEmailOrCreate(String email, Integer age) 메서드를 구현했습니다. 해당 메서드가 필요한 상황은 TokenService에서 깃헙에서 받아온 email로 유저가 존재하는지 체크하고 없으면 생성이 필요한 상황이였습니다. 궁금한건 멤버의 존재유무는 email로만 진행되니 find가 성공하면 파라미터로 넘긴 age 는 불필요한 상황이 발생합니다. 특정 케이스에 따라서 파라미터가 사용되게 메서드를 구현해도 괜찮을까요 ?

감사합니다. ! 

